### PR TITLE
TKC-5094 chore(UI): Showing Errored Status for Aborted Executions

### DIFF
--- a/plugins/testkube/src/components/molecules/ExecutionStatusBadge/ExecutionStatusBadge.tsx
+++ b/plugins/testkube/src/components/molecules/ExecutionStatusBadge/ExecutionStatusBadge.tsx
@@ -13,7 +13,7 @@ export const ExecutionStatusBadge = ({ status }: { status: string }) => {
     case 'failed':
       return <StatusError>Failed</StatusError>;
     case 'aborted':
-      return <StatusAborted>Aborted</StatusAborted>;
+      return <StatusError>Aborted</StatusError>;
     case 'queued':
       return <StatusPending>Queued</StatusPending>;
     case 'running':


### PR DESCRIPTION
This PR updates the Aborted status icon to use the error icon

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
