### PR TITLE
chore(alpha): Updating Frontend Plugin for Alpha Support

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -119,6 +119,7 @@ permission:
 testkube:
   apiUrl: 'http://localhost:8088'
 
+  # skipTlsVerify: false
   # enterprise settings
   # enterprise: true
   # uiUrl: https://app.testkube.io

--- a/plugins/testkube-backend/package.json
+++ b/plugins/testkube-backend/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.7.0",
     "@backstage/config": "^1.3.6",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "undici": "^8.0.2"
   },
   "devDependencies": {
     "@backstage/cli": "^0.35.4",

--- a/plugins/testkube-backend/src/services/configService.ts
+++ b/plugins/testkube-backend/src/services/configService.ts
@@ -4,6 +4,7 @@ export type Config = {
   url: string;
   isEnterprise: boolean;
   uiUrl?: string;
+  skipTlsVerify: boolean;
 
   organizations: {
     id: string;
@@ -35,11 +36,15 @@ const ConfigService = (): ConfigService => ({
       apiKey: config.getString('apiKey') ?? '',
     }));
 
+    const skipTlsVerify =
+      backstageConfig.getOptionalBoolean('testkube.skipTlsVerify') ?? false;
+
     return {
       url: baseUrl.replace(/\/$/, ''),
       uiUrl: uiUrl?.replace(/\/$/, ''),
       isEnterprise,
       organizations,
+      skipTlsVerify,
     };
   },
 

--- a/plugins/testkube-backend/src/services/enterpriseService.ts
+++ b/plugins/testkube-backend/src/services/enterpriseService.ts
@@ -153,7 +153,8 @@ const EnterpriseService = ({
       throw new Error(`Failed to fetch environments for organization ${orgId}`);
     }
 
-    const { elements = [] }: ListEnvironmentsResponse = await response.json();
+    const { elements = [] } =
+      (await response.json()) as ListEnvironmentsResponse;
 
     const environments: EnvironmentMetadata[] = elements.map(
       ({ id, slug, name }) => ({
@@ -218,7 +219,7 @@ const EnterpriseService = ({
           throw new Error(`Failed to fetch organization ${id}`);
         }
 
-        const organizationApi: OrganizationApi = await organization.json();
+        const organizationApi = (await organization.json()) as OrganizationApi;
 
         return organizationApi;
       }),

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -1,3 +1,9 @@
+import {
+  Agent,
+  fetch as undiciFetch,
+  type Response as UndiciResponse,
+} from 'undici';
+
 import type { LoggerService } from '@backstage/backend-plugin-api';
 import type { Config } from './configService';
 
@@ -14,7 +20,7 @@ type ProxyService = {
     orgId?: string;
     envId?: string;
     apiKey?: string;
-  }): Promise<Response>;
+  }): Promise<UndiciResponse>;
 };
 
 type ProxyServiceParams = {
@@ -64,29 +70,29 @@ const skipHeaders = new Set([
 const buildHeaders = (
   incomingHeaders?: IncomingHeaders,
   apiKey?: string,
-): Headers => {
-  const headers = new Headers({
+): Record<string, string> => {
+  const headers: Record<string, string> = {
     'User-Agent': 'backstage-testkube-backend',
-  });
+  };
 
   if (incomingHeaders) {
     for (const [key, value] of Object.entries(incomingHeaders)) {
       if (value && !skipHeaders.has(key.toLowerCase())) {
-        headers.set(key, Array.isArray(value) ? value.join(', ') : value);
+        headers[key] = Array.isArray(value) ? value.join(', ') : value;
       }
     }
   }
 
-  if (!headers.has('Accept')) {
-    headers.set('Accept', 'application/json');
+  if (!headers.Accept) {
+    headers.Accept = 'application/json';
   }
 
-  if (!headers.has('Content-Type')) {
-    headers.set('Content-Type', 'application/json');
+  if (!headers['Content-Type']) {
+    headers['Content-Type'] = 'application/json';
   }
 
   if (apiKey) {
-    headers.set('Authorization', `Bearer ${apiKey}`);
+    headers.Authorization = `Bearer ${apiKey}`;
   }
 
   return headers;
@@ -109,13 +115,18 @@ const ProxyService = ({
     });
 
     try {
-      const response = await fetch(targetUrl, {
+      const response = await undiciFetch(targetUrl, {
         method,
         headers,
         body:
           body && !['GET', 'DELETE'].includes(method as string)
             ? JSON.stringify(body)
             : undefined,
+        ...(config.skipTlsVerify
+          ? {
+              dispatcher: new Agent({ connect: { rejectUnauthorized: false } }),
+            }
+          : {}),
       });
 
       logger.info('Received response from Testkube API', {
@@ -126,11 +137,16 @@ const ProxyService = ({
 
       return response;
     } catch (error) {
+      const cause =
+        error instanceof Error && 'cause' in error
+          ? (error.cause as Error)?.message ?? error.cause
+          : undefined;
       logger.error('Network error while calling Testkube API', {
         method,
         path,
         targetUrl,
         error: error instanceof Error ? error.message : 'Unknown network error',
+        cause,
       });
       throw error;
     }

--- a/plugins/testkube/README.md
+++ b/plugins/testkube/README.md
@@ -71,7 +71,26 @@ You can find a working example of this configuration in this repository’s root
 
 ### Adding Testkube plugin pages
 
-#### Testkube Dashboard
+#### Using the new frontend system (alpha)
+
+If your Backstage app uses the [new frontend system](https://backstage.io/docs/frontend-system/), you can install the plugin by importing it from the `/alpha` subpath and adding it to your app features in `packages/app/src/App.tsx`:
+
+```tsx
+import { createApp } from '@backstage/frontend-defaults';
+import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import testkubePlugin from '@testkube/backstage-plugin/alpha';
+import { navModule } from './modules/nav';
+
+export default createApp({
+  features: [catalogPlugin, navModule, testkubePlugin],
+});
+```
+
+This automatically registers the **Testkube Dashboard** page at `/testkube` and the **Testkube Entity Page** content on catalog entities with the `testkube.io/labels` annotation. No additional route or entity page configuration is needed.
+
+#### Using the legacy frontend system
+
+##### Testkube Dashboard
 
 To enable **Testkube Dashboard** into your Backstage project edit the file `packages/app/src/App.tsx` to include the following lines:
 

--- a/plugins/testkube/package.json
+++ b/plugins/testkube/package.json
@@ -29,7 +29,7 @@
     "@backstage/core-compat-api": "^0.3.5",
     "@backstage/core-components": "^0.18.7",
     "@backstage/core-plugin-api": "^1.12.3",
-    "@backstage/frontend-plugin-api": "^0.10.0",
+    "@backstage/frontend-plugin-api": "^0.15.0",
     "@backstage/plugin-catalog-react": "^2.0.0",
     "@backstage/theme": "^0.7.2",
     "@emotion/react": "^11.14.0",

--- a/plugins/testkube/src/alpha.tsx
+++ b/plugins/testkube/src/alpha.tsx
@@ -1,50 +1,68 @@
 import {
   ApiBlueprint,
   createApiFactory,
-  createFrontendPlugin,
-  discoveryApiRef,
   identityApiRef,
+  discoveryApiRef,
+  createFrontendPlugin,
+  createRouteRef,
   PageBlueprint,
+  ExtensionDefinition,
 } from '@backstage/frontend-plugin-api';
-import { testkubeApiRef, TestkubeClient } from './api';
+import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { testkubeApiRef } from './api/TestkubeApi';
+import { TestkubeClient } from './api/TestkubeClient';
+import BugReportIcon from '@material-ui/icons/BugReport';
 
-export const testkubeApi = ApiBlueprint.make({
+const testkubeDashboardRouteRef = createRouteRef();
+
+const testkubeApi = ApiBlueprint.make({
   name: 'testkubeApi',
-  params: {
-    factory: createApiFactory({
-      api: testkubeApiRef,
-      deps: {
-        discoveryApi: discoveryApiRef,
-        identityApi: identityApiRef,
-      },
-      factory: ({ discoveryApi, identityApi }) =>
-        new TestkubeClient({
-          discoveryApi,
-          identityApi,
-        }),
-    }),
-  },
+  params: defineParams =>
+    defineParams(
+      createApiFactory({
+        api: testkubeApiRef,
+        deps: {
+          discoveryApi: discoveryApiRef,
+          identityApi: identityApiRef,
+        },
+        factory: ({ discoveryApi, identityApi }) =>
+          new TestkubeClient({ discoveryApi, identityApi }),
+      }),
+    ),
 });
 
 const TestkubeDashboardPage = PageBlueprint.make({
+  name: 'dashboard',
   params: {
-    defaultPath: '/testkube',
+    path: '/testkube',
+    title: 'Testkube',
+    icon: <BugReportIcon />,
+    routeRef: testkubeDashboardRouteRef,
     loader: () =>
-      import('./components/pages/DashboardPage').then(
-        m => m.DashboardPage as any,
-      ),
+      import('./components/pages/DashboardPage').then(m => <m.DashboardPage />),
   },
 });
 
-const TestkubeEntityPage = PageBlueprint.make({
+const TestkubeEntityContent = EntityContentBlueprint.make({
+  name: 'tests-summary',
   params: {
-    defaultPath: '/tests-summary',
+    path: '/tests-summary',
+    title: 'Testkube',
     loader: () =>
-      import('./components/pages/EntityPage').then(m => m.EntityPage as any),
+      import('./components/pages/EntityPage').then(m => <m.EntityPage />),
   },
 });
+
+const extensions: ExtensionDefinition[] = [
+  testkubeApi as ExtensionDefinition,
+  TestkubeDashboardPage as ExtensionDefinition,
+  TestkubeEntityContent as ExtensionDefinition,
+];
 
 export default createFrontendPlugin({
-  id: 'testkube',
-  extensions: [testkubeApi, TestkubeDashboardPage, TestkubeEntityPage],
+  pluginId: 'testkube',
+  routes: {
+    root: testkubeDashboardRouteRef,
+  },
+  extensions,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,7 +2074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.3, @backstage/config@npm:^1.3.6":
+"@backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.6":
   version: 1.3.6
   resolution: "@backstage/config@npm:1.3.6"
   dependencies:
@@ -2211,60 +2211,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:^0.17.4":
-  version: 0.17.5
-  resolution: "@backstage/core-components@npm:0.17.5"
-  dependencies:
-    "@backstage/config": "npm:^1.3.3"
-    "@backstage/core-plugin-api": "npm:^1.10.9"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/theme": "npm:^0.6.8"
-    "@backstage/version-bridge": "npm:^1.0.11"
-    "@dagrejs/dagre": "npm:^1.1.4"
-    "@date-io/core": "npm:^1.3.13"
-    "@material-table/core": "npm:^3.1.0"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    "@testing-library/react": "npm:^16.0.0"
-    "@types/react-sparklines": "npm:^1.7.0"
-    ansi-regex: "npm:^6.0.1"
-    classnames: "npm:^2.2.6"
-    d3-selection: "npm:^3.0.0"
-    d3-shape: "npm:^3.0.0"
-    d3-zoom: "npm:^3.0.0"
-    js-yaml: "npm:^4.1.0"
-    linkify-react: "npm:4.3.2"
-    linkifyjs: "npm:4.3.2"
-    lodash: "npm:^4.17.21"
-    pluralize: "npm:^8.0.0"
-    qs: "npm:^6.9.4"
-    rc-progress: "npm:3.5.1"
-    react-helmet: "npm:6.1.0"
-    react-hook-form: "npm:^7.12.2"
-    react-idle-timer: "npm:5.7.2"
-    react-markdown: "npm:^8.0.0"
-    react-sparklines: "npm:^1.7.0"
-    react-syntax-highlighter: "npm:^15.4.5"
-    react-use: "npm:^17.3.2"
-    react-virtualized-auto-sizer: "npm:^1.0.11"
-    react-window: "npm:^1.8.6"
-    remark-gfm: "npm:^3.0.1"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:^3.22.4"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/78b4628158f0ad10191e8a201a32a035605b297713a48c6ae84ad928219e794ea01e5c833acab891214eaaa49ab99939e3c87963248626fc5462a8077fe05e68
-  languageName: node
-  linkType: hard
-
 "@backstage/core-components@npm:^0.18.7":
   version: 0.18.7
   resolution: "@backstage/core-components@npm:0.18.7"
@@ -2323,7 +2269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:^1.10.4, @backstage/core-plugin-api@npm:^1.10.9, @backstage/core-plugin-api@npm:^1.12.3":
+"@backstage/core-plugin-api@npm:^1.10.4, @backstage/core-plugin-api@npm:^1.12.3":
   version: 1.12.3
   resolution: "@backstage/core-plugin-api@npm:1.12.3"
   dependencies:
@@ -2422,27 +2368,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:^0.10.0":
-  version: 0.10.4
-  resolution: "@backstage/frontend-plugin-api@npm:0.10.4"
+"@backstage/filter-predicates@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@backstage/filter-predicates@npm:0.1.1"
   dependencies:
-    "@backstage/core-components": "npm:^0.17.4"
-    "@backstage/core-plugin-api": "npm:^1.10.9"
-    "@backstage/types": "npm:^1.2.1"
-    "@backstage/version-bridge": "npm:^1.0.11"
-    "@material-ui/core": "npm:^4.12.4"
-    lodash: "npm:^4.17.21"
-    zod: "npm:^3.22.4"
-    zod-to-json-schema: "npm:^3.21.4"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/06577c8e7b25bfa622e2628466d2c154168d042594334a06971759059f1842b30223cbdefad30e31119b46658542230245677aab88b49160312aba91eb7647fa
+    "@backstage/config": "npm:^1.3.6"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.2"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10c0/f4bce2259af0e953ef30d292394aeea614ae42fbd825678a3abc36a97a6020a9964f40046aa3dc189f040ecf9674fb30dbcbbfd2ff3f807a513ad0353094bea5
   languageName: node
   linkType: hard
 
@@ -2464,6 +2399,28 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/f25e216e6d10354c27cb90bb65e09aa0d9c6f3ba11fd29214833ddb59d45225e1893eb72637107d858490edde14ea97e31657525bc2f3d5a50d526dfc5dbcaa9
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:^0.15.0":
+  version: 0.15.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.15.1"
+  dependencies:
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/filter-predicates": "npm:^0.1.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/8064e0845849f7f27af62ff30007bc08a89fc052330e46138735669280e962f2643485a5e2e38dcec16d0ad8a93c150d5fc0b94b9e045106cba11c23bff365dc
   languageName: node
   linkType: hard
 
@@ -4240,7 +4197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:^0.6.4, @backstage/theme@npm:^0.6.8":
+"@backstage/theme@npm:^0.6.4":
   version: 0.6.8
   resolution: "@backstage/theme@npm:0.6.8"
   dependencies:
@@ -13293,7 +13250,7 @@ __metadata:
     "@backstage/core-components": "npm:^0.18.7"
     "@backstage/core-plugin-api": "npm:^1.12.3"
     "@backstage/dev-utils": "npm:^1.1.20"
-    "@backstage/frontend-plugin-api": "npm:^0.10.0"
+    "@backstage/frontend-plugin-api": "npm:^0.15.0"
     "@backstage/plugin-catalog-react": "npm:^2.0.0"
     "@backstage/test-utils": "npm:^1.7.15"
     "@backstage/theme": "npm:^0.7.2"
@@ -33825,7 +33782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.3.5":
+"zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.3.5":
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307

--- a/yarn.lock
+++ b/yarn.lock
@@ -13236,6 +13236,7 @@ __metadata:
     "@backstage/config": "npm:^1.3.6"
     "@types/express": "npm:^4.17.21"
     express: "npm:^4.21.0"
+    undici: "npm:^8.0.2"
   languageName: unknown
   linkType: soft
 
@@ -32462,6 +32463,13 @@ __metadata:
   version: 7.22.0
   resolution: "undici@npm:7.22.0"
   checksum: 10c0/09777c06f3f18f761f03e3a4c9c04fd9fcca8ad02ccea43602ee4adf73fcba082806f1afb637f6ea714ef6279c5323c25b16d435814c63db720f63bfc20d316b
+  languageName: node
+  linkType: hard
+
+"undici@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "undici@npm:8.0.2"
+  checksum: 10c0/4f833ab3a154ea11e2c53b272592f62269ecc7040a8bae5147c56ec1ccf67ccdf50d93abb84a48f0ba29947cca78d99d8ca873cacf53924c4b884c7d9bf783f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR add support to skip the tls verify for the proxy requests to the testkube API

## Changes

- Adds skip verify option

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
