### PR TITLE
TKC-5498 feat(proxy): Adding Support for Certificate Files

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -120,6 +120,7 @@ testkube:
   apiUrl: 'http://localhost:8088'
 
   # skipTlsVerify: false
+  # caFilePath: /path/to/ca.crt
   # enterprise settings
   # enterprise: true
   # uiUrl: https://app.testkube.io

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -45,7 +45,7 @@
     "@backstage/plugin-search-backend-node": "^1.4.1",
     "@backstage/plugin-signals-backend": "^0.3.12",
     "@backstage/plugin-techdocs-backend": "^2.1.5",
-    "@testkube/backstage-plugin-backend": "workspace:^",
+    "@testkube/backstage-plugin-backend": "workspace:*",
     "app": "link:../app",
     "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",

--- a/plugins/testkube-backend/README.md
+++ b/plugins/testkube-backend/README.md
@@ -50,6 +50,20 @@ testkube:
 
 This should point to the HTTP endpoint of your Testkube API server.
 
+### Custom CA certificates
+
+If your Testkube API uses a certificate signed by a private or internal CA, you can provide a path to a PEM file containing the CA certificate(s) instead of disabling TLS verification with `skipTlsVerify`:
+
+```yaml
+testkube:
+  apiUrl: 'https://testkube.internal.example.com'
+  caFilePath: '/etc/ssl/certs/internal-ca.pem'
+```
+
+> **Note**
+>
+> If both `skipTlsVerify` and `caFilePath` are set, `skipTlsVerify` takes precedence and certificate validation is disabled entirely.
+
 ### Enterprise setup (optional)
 
 When using Testkube Enterprise, you can configure multiple organizations and environments. The backend plugin will:

--- a/plugins/testkube-backend/config.d.ts
+++ b/plugins/testkube-backend/config.d.ts
@@ -6,5 +6,7 @@ export interface Config {
       /** API key or token sent to Testkube API (e.g. from env: ${TESTKUBE_API_KEY}) */
       apiKey?: string;
     };
+    /** Path to a PEM file containing custom CA certificates for TLS verification */
+    caFilePath?: string;
   };
 }

--- a/plugins/testkube-backend/src/services/configService.test.ts
+++ b/plugins/testkube-backend/src/services/configService.test.ts
@@ -1,0 +1,82 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+
+import ConfigService, { type Config } from './configService';
+
+const baseConfig = (overrides: Partial<Config> = {}): Config => ({
+  url: 'https://api.testkube.io',
+  isEnterprise: false,
+  skipTlsVerify: false,
+  organizations: [],
+  ...overrides,
+});
+
+describe('ConfigService.validate', () => {
+  const configService = ConfigService();
+
+  it('returns no errors for a valid minimal config', () => {
+    const errors = configService.validate(baseConfig());
+    expect(errors).toEqual([]);
+  });
+
+  it('returns an error when url is empty', () => {
+    const errors = configService.validate(baseConfig({ url: '' }));
+    expect(errors).toContain('Testkube API URL is required');
+  });
+
+  describe('caFilePath validation', () => {
+    let tmpDir: string;
+    let validCaPath: string;
+
+    beforeAll(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'configService-test-'));
+      validCaPath = join(tmpDir, 'ca.pem');
+      writeFileSync(
+        validCaPath,
+        '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n',
+      );
+    });
+
+    afterAll(() => {
+      try {
+        unlinkSync(validCaPath);
+      } catch {
+        // ignore
+      }
+    });
+
+    it('returns no errors when caFilePath points to a readable file', () => {
+      const errors = configService.validate(
+        baseConfig({ caFilePath: validCaPath }),
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('returns an error when caFilePath points to a non-existent file', () => {
+      const errors = configService.validate(
+        baseConfig({ caFilePath: '/tmp/does-not-exist-ca.pem' }),
+      );
+      expect(errors).toContain(
+        "CA certificate file is not readable at '/tmp/does-not-exist-ca.pem'",
+      );
+    });
+
+    it('skips caFilePath validation when skipTlsVerify is true', () => {
+      const errors = configService.validate(
+        baseConfig({
+          caFilePath: '/tmp/does-not-exist-ca.pem',
+          skipTlsVerify: true,
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('returns no errors when caFilePath is undefined', () => {
+      const errors = configService.validate(
+        baseConfig({ caFilePath: undefined }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+});

--- a/plugins/testkube-backend/src/services/configService.test.ts
+++ b/plugins/testkube-backend/src/services/configService.test.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
 
 import ConfigService, { type Config } from './configService';
 
@@ -39,11 +39,7 @@ describe('ConfigService.validate', () => {
     });
 
     afterAll(() => {
-      try {
-        unlinkSync(validCaPath);
-      } catch {
-        // ignore
-      }
+      rmSync(tmpDir, { recursive: true, force: true });
     });
 
     it('returns no errors when caFilePath points to a readable file', () => {
@@ -77,6 +73,13 @@ describe('ConfigService.validate', () => {
         baseConfig({ caFilePath: undefined }),
       );
       expect(errors).toEqual([]);
+    });
+
+    it('returns an error when caFilePath points to a directory', () => {
+      const errors = configService.validate(baseConfig({ caFilePath: tmpDir }));
+      expect(errors).toContain(
+        `CA certificate path is not a regular file: '${tmpDir}'`,
+      );
     });
   });
 });

--- a/plugins/testkube-backend/src/services/configService.ts
+++ b/plugins/testkube-backend/src/services/configService.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants } from 'node:fs';
+import { statSync } from 'node:fs';
 
 import type { Config as BackstageConfig } from '@backstage/config';
 
@@ -71,7 +71,12 @@ const ConfigService = (): ConfigService => ({
 
     if (config.caFilePath && !config.skipTlsVerify) {
       try {
-        accessSync(config.caFilePath, constants.R_OK);
+        const stat = statSync(config.caFilePath);
+        if (!stat.isFile()) {
+          errors.push(
+            `CA certificate path is not a regular file: '${config.caFilePath}'`,
+          );
+        }
       } catch {
         errors.push(
           `CA certificate file is not readable at '${config.caFilePath}'`,

--- a/plugins/testkube-backend/src/services/configService.ts
+++ b/plugins/testkube-backend/src/services/configService.ts
@@ -1,3 +1,5 @@
+import { accessSync, constants } from 'node:fs';
+
 import type { Config as BackstageConfig } from '@backstage/config';
 
 export type Config = {
@@ -65,6 +67,16 @@ const ConfigService = (): ConfigService => ({
 
     if (config.isEnterprise && !config.uiUrl) {
       errors.push('Testkube UI URL is required for enterprise mode');
+    }
+
+    if (config.caFilePath && !config.skipTlsVerify) {
+      try {
+        accessSync(config.caFilePath, constants.R_OK);
+      } catch {
+        errors.push(
+          `CA certificate file is not readable at '${config.caFilePath}'`,
+        );
+      }
     }
 
     return errors;

--- a/plugins/testkube-backend/src/services/configService.ts
+++ b/plugins/testkube-backend/src/services/configService.ts
@@ -5,6 +5,7 @@ export type Config = {
   isEnterprise: boolean;
   uiUrl?: string;
   skipTlsVerify: boolean;
+  caFilePath?: string;
 
   organizations: {
     id: string;
@@ -39,12 +40,16 @@ const ConfigService = (): ConfigService => ({
     const skipTlsVerify =
       backstageConfig.getOptionalBoolean('testkube.skipTlsVerify') ?? false;
 
+    const caFilePath =
+      backstageConfig.getOptionalString('testkube.caFilePath') ?? undefined;
+
     return {
       url: baseUrl.replace(/\/$/, ''),
       uiUrl: uiUrl?.replace(/\/$/, ''),
       isEnterprise,
       organizations,
       skipTlsVerify,
+      caFilePath,
     };
   },
 

--- a/plugins/testkube-backend/src/services/proxyService.test.ts
+++ b/plugins/testkube-backend/src/services/proxyService.test.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
 
 import type { LoggerService } from '@backstage/backend-plugin-api';
 import type { Config } from './configService';
@@ -53,11 +53,7 @@ describe('ProxyService TLS configuration', () => {
   });
 
   afterAll(() => {
-    try {
-      unlinkSync(validCaPath);
-    } catch {
-      // ignore
-    }
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
   beforeEach(() => {

--- a/plugins/testkube-backend/src/services/proxyService.test.ts
+++ b/plugins/testkube-backend/src/services/proxyService.test.ts
@@ -1,0 +1,141 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+
+import type { LoggerService } from '@backstage/backend-plugin-api';
+import type { Config } from './configService';
+
+// Mock undici so we can inspect the dispatcher passed to fetch
+const mockFetch = jest.fn().mockResolvedValue({
+  status: 200,
+  ok: true,
+  json: async () => ({}),
+});
+
+jest.mock('undici', () => {
+  const { Agent } = jest.requireActual('undici');
+  return {
+    Agent,
+    fetch: (...args: unknown[]) => mockFetch(...args),
+  };
+});
+
+import ProxyService from './proxyService';
+import { Agent } from 'undici';
+
+const mockLogger: LoggerService = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+const baseConfig = (overrides: Partial<Config> = {}): Config => ({
+  url: 'https://api.testkube.io',
+  isEnterprise: false,
+  skipTlsVerify: false,
+  organizations: [],
+  ...overrides,
+});
+
+describe('ProxyService TLS configuration', () => {
+  let tmpDir: string;
+  let validCaPath: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'proxyService-test-'));
+    validCaPath = join(tmpDir, 'ca.pem');
+    writeFileSync(
+      validCaPath,
+      '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n',
+    );
+  });
+
+  afterAll(() => {
+    try {
+      unlinkSync(validCaPath);
+    } catch {
+      // ignore
+    }
+  });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    (mockLogger.info as jest.Mock).mockClear();
+    (mockLogger.debug as jest.Mock).mockClear();
+  });
+
+  it('passes no dispatcher when neither skipTlsVerify nor caFilePath is set', async () => {
+    const proxy = ProxyService({ config: baseConfig(), logger: mockLogger });
+    await proxy.send({ path: '/v1/test', method: 'GET' });
+
+    const fetchOptions = mockFetch.mock.calls[0][1];
+    expect(fetchOptions.dispatcher).toBeUndefined();
+  });
+
+  it('passes an Agent with rejectUnauthorized=false when skipTlsVerify is true', async () => {
+    const proxy = ProxyService({
+      config: baseConfig({ skipTlsVerify: true }),
+      logger: mockLogger,
+    });
+    await proxy.send({ path: '/v1/test', method: 'GET' });
+
+    const fetchOptions = mockFetch.mock.calls[0][1];
+    expect(fetchOptions.dispatcher).toBeInstanceOf(Agent);
+  });
+
+  it('passes an Agent with ca when caFilePath is set', async () => {
+    const proxy = ProxyService({
+      config: baseConfig({ caFilePath: validCaPath }),
+      logger: mockLogger,
+    });
+    await proxy.send({ path: '/v1/test', method: 'GET' });
+
+    const fetchOptions = mockFetch.mock.calls[0][1];
+    expect(fetchOptions.dispatcher).toBeInstanceOf(Agent);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Using custom CA certificate for TLS',
+      expect.objectContaining({ path: validCaPath }),
+    );
+  });
+
+  it('skipTlsVerify takes precedence over caFilePath', async () => {
+    const proxy = ProxyService({
+      config: baseConfig({ skipTlsVerify: true, caFilePath: validCaPath }),
+      logger: mockLogger,
+    });
+    await proxy.send({ path: '/v1/test', method: 'GET' });
+
+    const fetchOptions = mockFetch.mock.calls[0][1];
+    expect(fetchOptions.dispatcher).toBeInstanceOf(Agent);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'TLS verification disabled (skipTlsVerify)',
+    );
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      'Loaded custom CA certificate',
+      expect.anything(),
+    );
+  });
+
+  it('does not read caFilePath when skipTlsVerify is true (bad path does not throw)', () => {
+    expect(() =>
+      ProxyService({
+        config: baseConfig({
+          skipTlsVerify: true,
+          caFilePath: '/nonexistent/bad.pem',
+        }),
+        logger: mockLogger,
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws with cause when caFilePath is unreadable and skipTlsVerify is false', () => {
+    expect(() =>
+      ProxyService({
+        config: baseConfig({ caFilePath: '/nonexistent/bad.pem' }),
+        logger: mockLogger,
+      }),
+    ).toThrow("Failed to read CA certificate file at '/nonexistent/bad.pem'");
+  });
+});

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -101,7 +101,7 @@ const buildHeaders = (
 };
 
 const getCertBuffer = (
-  caFilePath: string,
+  caFilePath: string | undefined,
   logger: LoggerService,
 ): Buffer | undefined => {
   if (!caFilePath) return undefined;
@@ -112,9 +112,8 @@ const getCertBuffer = (
     return caCert;
   } catch (error) {
     throw new Error(
-      `Failed to read CA certificate file at '${caFilePath}': ${
-        error instanceof Error ? error.message : error
-      }`,
+      `Failed to read CA certificate file at '${caFilePath}'`,
+      { cause: error },
     );
   }
 };
@@ -141,7 +140,10 @@ const getDispatcher = (
 };
 
 const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
-  const caCert = getCertBuffer(config.caFilePath ?? '', logger);
+  const caCert = config.skipTlsVerify
+    ? undefined
+    : getCertBuffer(config.caFilePath, logger);
+
   logger.debug('Initializing ProxyService with configuration', {
     apiUrl: config.url,
     uiUrl: config.uiUrl,

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -111,10 +111,9 @@ const getCertBuffer = (
     logger.info('Loaded custom CA certificate', { path: caFilePath });
     return caCert;
   } catch (error) {
-    throw new Error(
-      `Failed to read CA certificate file at '${caFilePath}'`,
-      { cause: error },
-    );
+    throw new Error(`Failed to read CA certificate file at '${caFilePath}'`, {
+      cause: error,
+    });
   }
 };
 

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import {
   Agent,
   fetch as undiciFetch,
@@ -98,59 +100,107 @@ const buildHeaders = (
   return headers;
 };
 
-const ProxyService = ({
-  config,
-  logger,
-}: ProxyServiceParams): ProxyService => ({
-  async send({ path, method, body, incomingHeaders, orgId, envId, apiKey }) {
-    const targetUrl = getTargetUrl(config.url, path, orgId, envId);
-    const headers = buildHeaders(incomingHeaders, apiKey);
+const getCertBuffer = (
+  caFilePath: string,
+  logger: LoggerService,
+): Buffer | undefined => {
+  if (!caFilePath) return undefined;
 
-    logger.debug('Sending request to Testkube API', {
-      method,
-      path,
-      targetUrl,
-      hasOrgId: !!orgId,
-      hasEnvId: !!envId,
+  try {
+    const caCert = readFileSync(caFilePath);
+    logger.info('Loaded custom CA certificate', { path: caFilePath });
+    return caCert;
+  } catch (error) {
+    throw new Error(
+      `Failed to read CA certificate file at '${caFilePath}': ${
+        error instanceof Error ? error.message : error
+      }`,
+    );
+  }
+};
+
+const getDispatcher = (
+  config: Config,
+  caCert: Buffer | undefined,
+  logger: LoggerService,
+): Agent | undefined => {
+  if (config.skipTlsVerify) {
+    logger.info('TLS verification disabled (skipTlsVerify)');
+    return new Agent({ connect: { rejectUnauthorized: false } });
+  }
+
+  if (caCert) {
+    logger.info('Using custom CA certificate for TLS', {
+      path: config.caFilePath,
     });
 
-    try {
-      const response = await undiciFetch(targetUrl, {
-        method,
-        headers,
-        body:
-          body && !['GET', 'DELETE'].includes(method as string)
-            ? JSON.stringify(body)
-            : undefined,
-        ...(config.skipTlsVerify
-          ? {
-              dispatcher: new Agent({ connect: { rejectUnauthorized: false } }),
-            }
-          : {}),
-      });
+    return new Agent({ connect: { ca: caCert } });
+  }
 
-      logger.info('Received response from Testkube API', {
-        method,
-        path,
-        status: response.status,
-      });
+  return undefined;
+};
 
-      return response;
-    } catch (error) {
-      const cause =
-        error instanceof Error && 'cause' in error
-          ? (error.cause as Error)?.message ?? error.cause
-          : undefined;
-      logger.error('Network error while calling Testkube API', {
+const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
+  const caCert = getCertBuffer(config.caFilePath ?? '', logger);
+  logger.debug('Initializing ProxyService with configuration', {
+    apiUrl: config.url,
+    uiUrl: config.uiUrl,
+    isEnterprise: config.isEnterprise,
+    skipTlsVerify: config.skipTlsVerify,
+    caFilePath: config.caFilePath,
+    organizationsCount: config.organizations.length,
+  });
+
+  const dispatcher = getDispatcher(config, caCert, logger);
+
+  return {
+    async send({ path, method, body, incomingHeaders, orgId, envId, apiKey }) {
+      const targetUrl = getTargetUrl(config.url, path, orgId, envId);
+      const headers = buildHeaders(incomingHeaders, apiKey);
+
+      logger.debug('Sending request to Testkube API', {
         method,
         path,
         targetUrl,
-        error: error instanceof Error ? error.message : 'Unknown network error',
-        cause,
+        hasOrgId: !!orgId,
+        hasEnvId: !!envId,
       });
-      throw error;
-    }
-  },
-});
+
+      try {
+        const response = await undiciFetch(targetUrl, {
+          method,
+          headers,
+          body:
+            body && !['GET', 'DELETE'].includes(method as string)
+              ? JSON.stringify(body)
+              : undefined,
+          ...(dispatcher ? { dispatcher } : {}),
+        });
+
+        logger.info('Received response from Testkube API', {
+          method,
+          path,
+          status: response.status,
+        });
+
+        return response;
+      } catch (error) {
+        const cause =
+          error instanceof Error && 'cause' in error
+            ? (error.cause as Error)?.message ?? error.cause
+            : undefined;
+        logger.error('Network error while calling Testkube API', {
+          method,
+          path,
+          targetUrl,
+          error:
+            error instanceof Error ? error.message : 'Unknown network error',
+          cause,
+        });
+        throw error;
+      }
+    },
+  };
+};
 
 export default ProxyService;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13227,7 +13227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testkube/backstage-plugin-backend@workspace:^, @testkube/backstage-plugin-backend@workspace:plugins/testkube-backend":
+"@testkube/backstage-plugin-backend@workspace:*, @testkube/backstage-plugin-backend@workspace:plugins/testkube-backend":
   version: 0.0.0-use.local
   resolution: "@testkube/backstage-plugin-backend@workspace:plugins/testkube-backend"
   dependencies:
@@ -15698,7 +15698,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": "npm:^1.4.1"
     "@backstage/plugin-signals-backend": "npm:^0.3.12"
     "@backstage/plugin-techdocs-backend": "npm:^2.1.5"
-    "@testkube/backstage-plugin-backend": "workspace:^"
+    "@testkube/backstage-plugin-backend": "workspace:*"
     app: "link:../app"
     better-sqlite3: "npm:^12.0.0"
     node-gyp: "npm:^10.0.0"


### PR DESCRIPTION
This PR adds support for custom TLS certificate files to use for the API requests

## Changes

- Adds support for provided certs
- Updates README

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
