### PR TITLE
chore(entities): Enabling Labels for Entities

### DIFF
--- a/plugins/testkube/src/alpha.tsx
+++ b/plugins/testkube/src/alpha.tsx
@@ -11,6 +11,7 @@ import {
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 import { testkubeApiRef } from './api/TestkubeApi';
 import { TestkubeClient } from './api/TestkubeClient';
+import { isTestkubeAvailable } from './hooks/useLabels';
 import BugReportIcon from '@material-ui/icons/BugReport';
 
 const testkubeDashboardRouteRef = createRouteRef();
@@ -48,6 +49,7 @@ const TestkubeEntityContent = EntityContentBlueprint.make({
   params: {
     path: '/tests-summary',
     title: 'Testkube',
+    filter: isTestkubeAvailable,
     loader: () =>
       import('./components/pages/EntityPage').then(m => <m.EntityPage />),
   },

--- a/plugins/testkube/src/components/pages/EntityPage/EntityPage.test.tsx
+++ b/plugins/testkube/src/components/pages/EntityPage/EntityPage.test.tsx
@@ -1,7 +1,7 @@
 import { EntityPage } from './EntityPage';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import {
   registerMswTestHooks,
   renderInTestApp,
@@ -37,6 +37,19 @@ describe('TestkubeEntityPage', () => {
 
   const testkubeApi: Partial<TestkubeApi> = {};
 
+  const createTestkubeApi = (
+    overrides: Partial<TestkubeApi> = {},
+  ): Partial<TestkubeApi> => ({
+    getConfig: jest.fn().mockResolvedValue({
+      isEnterprise: false,
+      organizationCount: 0,
+    }),
+    getRedirectUrl: jest
+      .fn()
+      .mockResolvedValue({ url: 'https://testkube.example' }),
+    ...overrides,
+  });
+
   it('should render', async () => {
     await renderInTestApp(
       <TestApiProvider apis={[[testkubeApiRef, testkubeApi]]}>
@@ -46,5 +59,66 @@ describe('TestkubeEntityPage', () => {
       </TestApiProvider>,
     );
     expect(screen.getByText('Loading data ...')).toBeInTheDocument();
+  });
+
+  it('passes entity label annotation to getTestWorkflowsWithExecutions', async () => {
+    const getTestWorkflowsWithExecutions = jest.fn().mockResolvedValue([]);
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            testkubeApiRef,
+            createTestkubeApi({ getTestWorkflowsWithExecutions }),
+          ],
+        ]}
+      >
+        <EntityProvider entity={entity}>
+          <EntityPage />
+        </EntityProvider>
+      </TestApiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getTestWorkflowsWithExecutions).toHaveBeenCalledWith(
+        { labels: 'app=test' },
+        { orgIndex: null, envSlug: null },
+      );
+    });
+  });
+
+  it('should not fetch or render entity content when labels annotation is missing', async () => {
+    const getTestWorkflowsWithExecutions = jest.fn().mockResolvedValue([]);
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            testkubeApiRef,
+            createTestkubeApi({ getTestWorkflowsWithExecutions }),
+          ],
+        ]}
+      >
+        <EntityProvider
+          entity={{
+            ...entity,
+            metadata: {
+              ...entity.metadata,
+              annotations: {
+                'testkube.io/organization': 'test',
+                'testkube.io/environments': 'dev,test',
+              },
+            },
+          }}
+        >
+          <EntityPage />
+        </EntityProvider>
+      </TestApiProvider>,
+    );
+    expect(screen.queryByText('Loading data ...')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('No executions were returned from Testkube.'),
+    ).not.toBeInTheDocument();
+    expect(getTestWorkflowsWithExecutions).not.toHaveBeenCalled();
   });
 });

--- a/plugins/testkube/src/components/pages/EntityPage/EntityPage.tsx
+++ b/plugins/testkube/src/components/pages/EntityPage/EntityPage.tsx
@@ -19,9 +19,14 @@ export const EntityPage: React.FC = withQueryProvider(() => {
     filters: {
       labels,
     },
+    enabled: Boolean(labels),
   });
 
   const classes = useStyles();
+
+  if (!labels) {
+    return null;
+  }
 
   if (isLoading) {
     return <Loading />;

--- a/plugins/testkube/src/components/pages/EntityPage/EntityPage.tsx
+++ b/plugins/testkube/src/components/pages/EntityPage/EntityPage.tsx
@@ -4,12 +4,12 @@ import { Error } from '../../molecules/Error';
 import { Loading } from '../../molecules/Loading/Loading';
 import { Table } from '../../organisms/ExecutionsDetailedTable';
 import { useStyles } from '../../organisms/ExecutionsDetailedTable/Heading';
-// import { useLabels } from '../../../hooks/useLabels';
+import { useLabels } from '../../../hooks/useLabels';
 import { QueryProvider as withQueryProvider } from '../../hoc/QueryProvider';
 import { useTestWorkflowsWithExecutions } from '../../../hooks/useApi';
 
 export const EntityPage: React.FC = withQueryProvider(() => {
-  // const labels = useLabels();
+  const labels = useLabels();
 
   const {
     data: { results } = {},
@@ -17,7 +17,7 @@ export const EntityPage: React.FC = withQueryProvider(() => {
     error,
   } = useTestWorkflowsWithExecutions({
     filters: {
-      // labels,
+      labels,
     },
   });
 

--- a/plugins/testkube/src/hooks/useApi.ts
+++ b/plugins/testkube/src/hooks/useApi.ts
@@ -125,6 +125,7 @@ export const useExecution = ({
 
 type UseTestWorkflowsWithExecutionsProps = {
   filters?: TestWorkflowWithExecutionsFilters;
+  enabled?: boolean;
 };
 
 const mapToExecutionResult = (
@@ -156,6 +157,7 @@ const mapToExecutionResult = (
 
 export const useTestWorkflowsWithExecutions = ({
   filters = {},
+  enabled = true,
 }: UseTestWorkflowsWithExecutionsProps = {}) => {
   const TestkubeAPI = useApi(testkubeApiRef);
   const orgEnv = useOrgEnvParams();
@@ -167,6 +169,7 @@ export const useTestWorkflowsWithExecutions = ({
       orgEnv.orgIndex,
       orgEnv.envSlug,
     ],
+    enabled,
     refetchInterval: defaultRefetchInterval,
     queryFn: async () => {
       const workflowsWithExecutions =

--- a/plugins/testkube/src/hooks/useLabels.ts
+++ b/plugins/testkube/src/hooks/useLabels.ts
@@ -2,13 +2,9 @@ import { TESTKUBE_LABELS } from '../constants/annotations';
 import { Entity } from '@backstage/catalog-model';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-export const useLabels = (): string => {
+export const useLabels = (): string | undefined => {
   const { entity } = useEntity();
-  const labels = entity.metadata.annotations?.[TESTKUBE_LABELS];
-  if (!labels) {
-    throw new Error("'testkube.io/labels' annotation is missing in the entity");
-  }
-  return labels;
+  return entity.metadata.annotations?.[TESTKUBE_LABELS];
 };
 
 export const isTestkubeAvailable = (entity: Entity) =>


### PR DESCRIPTION
This PR adds the missing labels filter for the entity pages

## Changes

- Removes the comments and adds labels support

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
