### PR TITLE
fix(backstage-backend): isolate proxy fetch path from undici global dispatcher

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+package-lock=false

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -117,15 +117,15 @@ permission:
   enabled: false
 
 testkube:
-  apiUrl: 'http://localhost:8088'
+  # apiUrl: 'http://localhost:8088'
 
   # skipTlsVerify: false
   # caFilePath: /path/to/ca.crt
   # enterprise settings
-  # enterprise: true
-  # uiUrl: https://app.testkube.io
-  # apiUrl: 'https://api.testkube.io'
+  enterprise: true
+  uiUrl: https://app.testkube.io
+  apiUrl: 'https://api.testkube.io'
   # add as many organizations as you need
-  # organizations:
-  #   - id: <your-organization-id>
-  #     apiKey: <your-api-key-with-only-read-access!!>
+  organizations:
+    - id: tkcorg_0f382d90e81ea228
+      apiKey: tkcapi_3caae18f3e6f0bed4fdbf17c42115e

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,7 +42,7 @@
     "@backstage/ui": "^0.12.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@testkube/backstage-plugin": "workspace:^",
+    "@testkube/backstage-plugin": "^0.1.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.30.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -45,8 +45,8 @@
     "@backstage/plugin-search-backend-node": "^1.4.1",
     "@backstage/plugin-signals-backend": "^0.3.12",
     "@backstage/plugin-techdocs-backend": "^2.1.5",
-    "@testkube/backstage-plugin-backend": "workspace:*",
-    "app": "link:../app",
+    "@testkube/backstage-plugin-backend": "0.1.0",
+    "app": "file:../app",
     "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"

--- a/plugins/testkube-backend/package.json
+++ b/plugins/testkube-backend/package.json
@@ -27,8 +27,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.7.0",
     "@backstage/config": "^1.3.6",
-    "express": "^4.21.0",
-    "undici": "^8.0.2"
+    "express": "^4.21.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.35.4",

--- a/plugins/testkube-backend/src/services/proxyService.test.ts
+++ b/plugins/testkube-backend/src/services/proxyService.test.ts
@@ -1,27 +1,23 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { EventEmitter } from 'node:events';
 
 import type { LoggerService } from '@backstage/backend-plugin-api';
 import type { Config } from './configService';
 
-// Mock undici so we can inspect the dispatcher passed to fetch
-const mockFetch = jest.fn().mockResolvedValue({
-  status: 200,
-  ok: true,
-  json: async () => ({}),
-});
+const mockHttpsRequest = jest.fn();
 
-jest.mock('undici', () => {
-  const { Agent } = jest.requireActual('undici');
+jest.mock('node:https', () => {
+  const actual = jest.requireActual('node:https');
   return {
-    Agent,
-    fetch: (...args: unknown[]) => mockFetch(...args),
+    ...actual,
+    request: (...args: unknown[]) => mockHttpsRequest(...args),
   };
 });
 
 import ProxyService from './proxyService';
-import { Agent } from 'undici';
+import { Agent } from 'node:https';
 
 const mockLogger: LoggerService = {
   info: jest.fn(),
@@ -42,6 +38,7 @@ const baseConfig = (overrides: Partial<Config> = {}): Config => ({
 describe('ProxyService TLS configuration', () => {
   let tmpDir: string;
   let validCaPath: string;
+  let fetchSpy: jest.SpiedFunction<typeof global.fetch>;
 
   beforeAll(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'proxyService-test-'));
@@ -50,46 +47,87 @@ describe('ProxyService TLS configuration', () => {
       validCaPath,
       '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n',
     );
+
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
   });
 
   afterAll(() => {
     rmSync(tmpDir, { recursive: true, force: true });
+    fetchSpy.mockRestore();
   });
 
   beforeEach(() => {
-    mockFetch.mockClear();
+    fetchSpy.mockClear();
+    mockHttpsRequest.mockReset();
     (mockLogger.info as jest.Mock).mockClear();
     (mockLogger.debug as jest.Mock).mockClear();
+
+    mockHttpsRequest.mockImplementation(
+      (_options: unknown, callback: (response: EventEmitter) => void) => {
+        const response = new EventEmitter() as EventEmitter & {
+          statusCode?: number;
+          statusMessage?: string;
+          headers: Record<string, string>;
+        };
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.headers = { 'content-type': 'application/json' };
+
+        const request = new EventEmitter() as EventEmitter & {
+          write: jest.Mock;
+          end: jest.Mock;
+        };
+        request.write = jest.fn();
+        request.end = jest.fn(() => {
+          callback(response);
+          response.emit('data', Buffer.from('{}'));
+          response.emit('end');
+        });
+
+        return request;
+      },
+    );
   });
 
-  it('passes no dispatcher when neither skipTlsVerify nor caFilePath is set', async () => {
+  it('uses global fetch when neither skipTlsVerify nor caFilePath is set', async () => {
     const proxy = ProxyService({ config: baseConfig(), logger: mockLogger });
     await proxy.send({ path: '/v1/test', method: 'GET' });
 
-    const fetchOptions = mockFetch.mock.calls[0][1];
-    expect(fetchOptions.dispatcher).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockHttpsRequest).not.toHaveBeenCalled();
   });
 
-  it('passes an Agent with rejectUnauthorized=false when skipTlsVerify is true', async () => {
+  it('uses HTTPS request with custom Agent when skipTlsVerify is true', async () => {
     const proxy = ProxyService({
       config: baseConfig({ skipTlsVerify: true }),
       logger: mockLogger,
     });
     await proxy.send({ path: '/v1/test', method: 'GET' });
 
-    const fetchOptions = mockFetch.mock.calls[0][1];
-    expect(fetchOptions.dispatcher).toBeInstanceOf(Agent);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+
+    const httpsOptions = mockHttpsRequest.mock.calls[0][0];
+    expect(httpsOptions.agent).toBeInstanceOf(Agent);
   });
 
-  it('passes an Agent with ca when caFilePath is set', async () => {
+  it('uses HTTPS request with custom Agent when caFilePath is set', async () => {
     const proxy = ProxyService({
       config: baseConfig({ caFilePath: validCaPath }),
       logger: mockLogger,
     });
     await proxy.send({ path: '/v1/test', method: 'GET' });
 
-    const fetchOptions = mockFetch.mock.calls[0][1];
-    expect(fetchOptions.dispatcher).toBeInstanceOf(Agent);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+
+    const httpsOptions = mockHttpsRequest.mock.calls[0][0];
+    expect(httpsOptions.agent).toBeInstanceOf(Agent);
     expect(mockLogger.info).toHaveBeenCalledWith(
       'Using custom CA certificate for TLS',
       expect.objectContaining({ path: validCaPath }),
@@ -103,8 +141,11 @@ describe('ProxyService TLS configuration', () => {
     });
     await proxy.send({ path: '/v1/test', method: 'GET' });
 
-    const fetchOptions = mockFetch.mock.calls[0][1];
-    expect(fetchOptions.dispatcher).toBeInstanceOf(Agent);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+
+    const httpsOptions = mockHttpsRequest.mock.calls[0][0];
+    expect(httpsOptions.agent).toBeInstanceOf(Agent);
     expect(mockLogger.info).toHaveBeenCalledWith(
       'TLS verification disabled (skipTlsVerify)',
     );

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -1,10 +1,6 @@
 import { readFileSync } from 'node:fs';
-
-import {
-  Agent,
-  fetch as undiciFetch,
-  type Response as UndiciResponse,
-} from 'undici';
+import { request as httpRequest } from 'node:http';
+import { Agent, request as httpsRequest } from 'node:https';
 
 import type { LoggerService } from '@backstage/backend-plugin-api';
 import type { Config } from './configService';
@@ -22,7 +18,7 @@ type ProxyService = {
     orgId?: string;
     envId?: string;
     apiKey?: string;
-  }): Promise<UndiciResponse>;
+  }): Promise<Response>;
 };
 
 type ProxyServiceParams = {
@@ -138,6 +134,72 @@ const getDispatcher = (
   return undefined;
 };
 
+const sendWithAgent = async ({
+  targetUrl,
+  method,
+  headers,
+  body,
+  agent,
+}: {
+  targetUrl: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+  agent: Agent;
+}): Promise<Response> => {
+  const url = new URL(targetUrl);
+  const requestFn = url.protocol === 'https:' ? httpsRequest : httpRequest;
+
+  return new Promise((resolve, reject) => {
+    const request = requestFn(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method,
+        headers,
+        ...(url.protocol === 'https:' ? { agent } : {}),
+      },
+      response => {
+        const chunks: Buffer[] = [];
+
+        response.on('data', chunk => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+
+        response.on('error', reject);
+        response.on('end', () => {
+          const responseHeaders = new Headers();
+
+          for (const [key, value] of Object.entries(response.headers)) {
+            if (value !== undefined) {
+              responseHeaders.set(
+                key,
+                Array.isArray(value) ? value.join(', ') : String(value),
+              );
+            }
+          }
+
+          resolve(
+            new Response(Buffer.concat(chunks), {
+              status: response.statusCode ?? 500,
+              statusText: response.statusMessage ?? '',
+              headers: responseHeaders,
+            }),
+          );
+        });
+      },
+    );
+
+    request.on('error', reject);
+    if (body) {
+      request.write(body);
+    }
+    request.end();
+  });
+};
+
 const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
   const caCert = config.skipTlsVerify
     ? undefined
@@ -158,6 +220,12 @@ const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
     async send({ path, method, body, incomingHeaders, orgId, envId, apiKey }) {
       const targetUrl = getTargetUrl(config.url, path, orgId, envId);
       const headers = buildHeaders(incomingHeaders, apiKey);
+      const methodValue = String(method);
+      const normalizedMethod = methodValue.toUpperCase();
+      const requestBody =
+        body && !['GET', 'DELETE'].includes(normalizedMethod)
+          ? JSON.stringify(body)
+          : undefined;
 
       logger.debug('Sending request to Testkube API', {
         method,
@@ -168,15 +236,19 @@ const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
       });
 
       try {
-        const response = await undiciFetch(targetUrl, {
-          method,
-          headers,
-          body:
-            body && !['GET', 'DELETE'].includes(method as string)
-              ? JSON.stringify(body)
-              : undefined,
-          ...(dispatcher ? { dispatcher } : {}),
-        });
+        const response = dispatcher
+          ? await sendWithAgent({
+              targetUrl,
+              method: methodValue,
+              headers,
+              body: requestBody,
+              agent: dispatcher,
+            })
+          : await fetch(targetUrl, {
+              method,
+              headers,
+              body: requestBody,
+            });
 
         logger.info('Received response from Testkube API', {
           method,

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -120,7 +120,7 @@ const getDispatcher = (
 ): Agent | undefined => {
   if (config.skipTlsVerify) {
     logger.info('TLS verification disabled (skipTlsVerify)');
-    return new Agent({ connect: { rejectUnauthorized: false } });
+    return new Agent({ rejectUnauthorized: false });
   }
 
   if (caCert) {
@@ -128,7 +128,7 @@ const getDispatcher = (
       path: config.caFilePath,
     });
 
-    return new Agent({ connect: { ca: caCert } });
+    return new Agent({ ca: caCert });
   }
 
   return undefined;

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -231,7 +231,7 @@ const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
           : undefined;
 
       logger.debug('Sending request to Testkube API', {
-        method,
+        method: normalizedMethod,
         path,
         targetUrl,
         hasOrgId: !!orgId,
@@ -242,19 +242,19 @@ const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
         const response = dispatcher
           ? await sendWithAgent({
               targetUrl,
-              method: methodValue,
+              method: normalizedMethod,
               headers,
               body: requestBody,
               agent: dispatcher,
             })
           : await fetch(targetUrl, {
-              method: methodValue,
+              method: normalizedMethod,
               headers,
               body: requestBody,
             });
 
         logger.info('Received response from Testkube API', {
-          method,
+          method: normalizedMethod,
           path,
           status: response.status,
         });
@@ -266,7 +266,7 @@ const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
             ? (error.cause as Error)?.message ?? error.cause
             : undefined;
         logger.error('Network error while calling Testkube API', {
-          method,
+          method: normalizedMethod,
           path,
           targetUrl,
           error:

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -174,10 +174,13 @@ const sendWithAgent = async ({
 
           for (const [key, value] of Object.entries(response.headers)) {
             if (value !== undefined) {
-              responseHeaders.set(
-                key,
-                Array.isArray(value) ? value.join(', ') : String(value),
-              );
+              if (Array.isArray(value)) {
+                for (const v of value) {
+                  responseHeaders.append(key, v);
+                }
+              } else {
+                responseHeaders.set(key, String(value));
+              }
             }
           }
 
@@ -220,7 +223,7 @@ const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
     async send({ path, method, body, incomingHeaders, orgId, envId, apiKey }) {
       const targetUrl = getTargetUrl(config.url, path, orgId, envId);
       const headers = buildHeaders(incomingHeaders, apiKey);
-      const methodValue = String(method);
+      const methodValue = method ?? 'GET';
       const normalizedMethod = methodValue.toUpperCase();
       const requestBody =
         body && !['GET', 'DELETE'].includes(normalizedMethod)
@@ -245,7 +248,7 @@ const ProxyService = ({ config, logger }: ProxyServiceParams): ProxyService => {
               agent: dispatcher,
             })
           : await fetch(targetUrl, {
-              method,
+              method: methodValue,
               headers,
               body: requestBody,
             });

--- a/plugins/testkube-backend/src/services/proxyService.ts
+++ b/plugins/testkube-backend/src/services/proxyService.ts
@@ -155,7 +155,7 @@ const sendWithAgent = async ({
       {
         protocol: url.protocol,
         hostname: url.hostname,
-        port: url.port,
+        port: url.port ? Number(url.port) : undefined,
         path: `${url.pathname}${url.search}`,
         method,
         headers,

--- a/plugins/testkube/package.json
+++ b/plugins/testkube/package.json
@@ -54,7 +54,8 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
     "msw": "^1.0.0",
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "files": [
     "alpha",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13227,7 +13227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testkube/backstage-plugin-backend@workspace:*, @testkube/backstage-plugin-backend@workspace:plugins/testkube-backend":
+"@testkube/backstage-plugin-backend@npm:0.1.0, @testkube/backstage-plugin-backend@workspace:plugins/testkube-backend":
   version: 0.0.0-use.local
   resolution: "@testkube/backstage-plugin-backend@workspace:plugins/testkube-backend"
   dependencies:
@@ -13239,7 +13239,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@testkube/backstage-plugin@workspace:^, @testkube/backstage-plugin@workspace:plugins/testkube":
+"@testkube/backstage-plugin@npm:^0.1.0, @testkube/backstage-plugin@workspace:plugins/testkube":
   version: 0.0.0-use.local
   resolution: "@testkube/backstage-plugin@workspace:plugins/testkube"
   dependencies:
@@ -13266,7 +13266,8 @@ __metadata:
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
     msw: "npm:^1.0.0"
-    react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    react: "npm:^18.0.0"
+    react-dom: "npm:^18.0.0"
     react-use: "npm:^17.2.4"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -15032,11 +15033,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"app@link:../app::locator=backend%40workspace%3Apackages%2Fbackend":
-  version: 0.0.0-use.local
-  resolution: "app@link:../app::locator=backend%40workspace%3Apackages%2Fbackend"
+"app@file:../app::locator=backend%40workspace%3Apackages%2Fbackend":
+  version: 0.0.0
+  resolution: "app@file:../app#../app::hash=dae84f&locator=backend%40workspace%3Apackages%2Fbackend"
+  dependencies:
+    "@backstage/app-defaults": "npm:^1.7.5"
+    "@backstage/catalog-model": "npm:^1.7.6"
+    "@backstage/cli": "npm:^0.35.4"
+    "@backstage/core-app-api": "npm:^1.19.5"
+    "@backstage/core-components": "npm:^0.18.7"
+    "@backstage/core-plugin-api": "npm:^1.12.3"
+    "@backstage/integration-react": "npm:^1.2.15"
+    "@backstage/plugin-api-docs": "npm:^0.13.4"
+    "@backstage/plugin-catalog": "npm:^1.33.0"
+    "@backstage/plugin-catalog-common": "npm:^1.1.8"
+    "@backstage/plugin-catalog-graph": "npm:^0.5.7"
+    "@backstage/plugin-catalog-import": "npm:^0.13.10"
+    "@backstage/plugin-catalog-react": "npm:^2.0.0"
+    "@backstage/plugin-kubernetes": "npm:^0.12.16"
+    "@backstage/plugin-notifications": "npm:^0.5.14"
+    "@backstage/plugin-org": "npm:^0.6.49"
+    "@backstage/plugin-permission-react": "npm:^0.4.40"
+    "@backstage/plugin-scaffolder": "npm:^1.35.3"
+    "@backstage/plugin-search": "npm:^1.6.0"
+    "@backstage/plugin-search-react": "npm:^1.10.3"
+    "@backstage/plugin-signals": "npm:^0.0.28"
+    "@backstage/plugin-techdocs": "npm:^1.17.0"
+    "@backstage/plugin-techdocs-module-addons-contrib": "npm:^1.1.33"
+    "@backstage/plugin-techdocs-react": "npm:^1.3.8"
+    "@backstage/plugin-user-settings": "npm:^0.9.0"
+    "@backstage/theme": "npm:^0.7.2"
+    "@backstage/ui": "npm:^0.12.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@testkube/backstage-plugin": "npm:^0.1.0"
+    react: "npm:^18.0.2"
+    react-dom: "npm:^18.0.2"
+    react-router: "npm:^6.30.2"
+    react-router-dom: "npm:^6.30.2"
+  checksum: 10c0/3027281f53f396526c47c892cb641a21388d625947802f556642cfaf5409769c57d669f9d6772193430ad5c2710765ba8d02659af66602ca6b0fa3c7192bf27c
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "app@workspace:packages/app":
   version: 0.0.0-use.local
@@ -15077,7 +15114,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
-    "@testkube/backstage-plugin": "workspace:^"
+    "@testkube/backstage-plugin": "npm:^0.1.0"
     "@types/react-dom": "npm:*"
     cross-env: "npm:^7.0.0"
     react: "npm:^18.0.2"
@@ -15697,8 +15734,8 @@ __metadata:
     "@backstage/plugin-search-backend-node": "npm:^1.4.1"
     "@backstage/plugin-signals-backend": "npm:^0.3.12"
     "@backstage/plugin-techdocs-backend": "npm:^2.1.5"
-    "@testkube/backstage-plugin-backend": "workspace:*"
-    app: "link:../app"
+    "@testkube/backstage-plugin-backend": "npm:0.1.0"
+    app: "file:../app"
     better-sqlite3: "npm:^12.0.0"
     node-gyp: "npm:^10.0.0"
     pg: "npm:^8.11.3"
@@ -28670,7 +28707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.0.2":
+"react-dom@npm:^18.0.0, react-dom@npm:^18.0.2":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -29174,7 +29211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^16.13.1 || ^17.0.0 || ^18.0.0, react@npm:^18.0.2":
+"react@npm:^18.0.0, react@npm:^18.0.2":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -13236,7 +13236,6 @@ __metadata:
     "@backstage/config": "npm:^1.3.6"
     "@types/express": "npm:^4.17.21"
     express: "npm:^4.21.0"
-    undici: "npm:^8.0.2"
   languageName: unknown
   linkType: soft
 
@@ -32463,13 +32462,6 @@ __metadata:
   version: 7.22.0
   resolution: "undici@npm:7.22.0"
   checksum: 10c0/09777c06f3f18f761f03e3a4c9c04fd9fcca8ad02ccea43602ee4adf73fcba082806f1afb637f6ea714ef6279c5323c25b16d435814c63db720f63bfc20d316b
-  languageName: node
-  linkType: hard
-
-"undici@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "undici@npm:8.0.2"
-  checksum: 10c0/4f833ab3a154ea11e2c53b272592f62269ecc7040a8bae5147c56ec1ccf67ccdf50d93abb84a48f0ba29947cca78d99d8ca873cacf53924c4b884c7d9bf783f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- replace external undici fetch usage in backend proxy service
- use Node global fetch for default requests
- use Node https request path with custom https.Agent when TLS overrides are configured (skipTlsVerify or caFilePath)
- remove direct undici dependency from @testkube/backstage-plugin-backend
- update unit tests to validate transport path selection and TLS behavior

## Why
Fixes cross-plugin interference reported in TKC-5909 where plugin-bundled undici behavior can impact other Backstage plugins in the same process.

## Validation
- corepack yarn workspace @testkube/backstage-plugin-backend test
- result: 1 test suite passed, 6 tests passed

## Tracking
- Linear: TKC-5909
- Freshdesk: 2131
