### PR TITLE
feat: add Testkube scaffolder workflow quality gate

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -68,17 +68,17 @@ catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.
   # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details
   # on how to get entities into the catalog.
-  locations: []
+  locations:
   # Local example data, replace this with your production config, these are intended for demo use only.
   # File locations are relative to the backend process, typically in a deployed context, such as in a Docker container, this will be the root
   # - type: file
   #   target: ./examples/entities.yaml
 
-  # # Local example template
-  # - type: file
-  #   target: ./examples/template/template.yaml
-  #   rules:
-  #   - allow: [ Template ]
+  # Local example template
+  - type: file
+    target: ./examples/template/template.yaml
+    rules:
+    - allow: [ Template ]
 
   # # Local example organizational data
   # - type: file
@@ -86,4 +86,4 @@ catalog:
   #   rules:
   #   - allow: [ User, Group ]
   rules:
-  - allow: [ Component, System, API, Resource, Location, User, Group ]
+  - allow: [ Component, Template, System, API, Resource, Location, User, Group ]

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -133,15 +133,17 @@ permission:
   enabled: false
 
 testkube:
-  apiUrl: 'http://localhost:8088'
+  enterprise: true
+  uiUrl: https://app.testkube.io
+  apiUrl: 'https://api.testkube.io'
+  organizations:
+  - id: 'tkcorg_0f382d90e81ea228'
+    apiKey: 'tkcapi_2070a606951e2b02a8c1e71239ccdd'
 
-  # skipTlsVerify: false
-  # caFilePath: /path/to/ca.crt
-  # enterprise settings
-  # enterprise: true
-  # uiUrl: https://app.testkube.io
-  # apiUrl: 'https://api.testkube.io'
-  # add as many organizations as you need
-  # organizations:
-  # - id: tkcorg_0000000000
-  #   apiKey: tkcapi_00000000000000000000000000000000
+# testkube:
+#   enterprise: true
+#   uiUrl: 'https://app.testkube.dev'
+#   apiUrl: 'https://api.testkube.dev'
+#   organizations:
+#     - id: 'tkcorg_9deb42dda2197657'
+#       apiKey: 'tkcapi_85efe2ae71cddcbb8a5d9d6aa4714f'

--- a/examples/template/template.yaml
+++ b/examples/template/template.yaml
@@ -2,70 +2,20 @@ apiVersion: scaffolder.backstage.io/v1beta3
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-template
 kind: Template
 metadata:
-  name: example-nodejs-template
-  title: Example Node.js Template
-  description: An example template for the scaffolder that creates a simple Node.js service
+  name: example-run-testworkflow
+  title: Example Run Testworkflow Template
+  description: An example template for the scaffolder that runs a Testkube workflow
 spec:
   owner: user:guest
   type: service
 
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
-  parameters:
-    - title: Fill in some steps
-      required:
-        - name
-      properties:
-        name:
-          title: Name
-          type: string
-          description: Unique name of the component
-          ui:autofocus: true
-          ui:options:
-            rows: 5
-    - title: Choose a location
-      required:
-        - repoUrl
-      properties:
-        repoUrl:
-          title: Repository Location
-          type: string
-          ui:field: RepoUrlPicker
-          ui:options:
-            allowedHosts:
-              - github.com
+  parameters: []
 
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
-    # Each step executes an action, in this case one templates files into the working directory.
-    - id: fetch-base
-      name: Fetch Base
-      action: fetch:template
-      input:
-        url: ./content
-        values:
-          name: ${{ parameters.name }}
-
-    # This step publishes the contents of the working directory to GitHub.
-    # If you or your organization prefer another default branch name over 'main'
-    # you can change that here.
-    - id: publish
-      name: Publish
-      action: publish:github
-      input:
-        allowedHosts: ['github.com']
-        description: This is ${{ parameters.name }}
-        repoUrl: ${{ parameters.repoUrl }}
-        defaultBranch: 'main'
-
-    # The final step is to register our new component in the catalog.
-    - id: register
-      name: Register
-      action: catalog:register
-      input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
-        catalogInfoPath: '/catalog-info.yaml'
 
     # Run the Testkube quality gate after the component is registered.
     - id: testkube
@@ -74,21 +24,9 @@ spec:
       input:
         workflows:
           - name: k6-sample
-        orgId: ${{ parameters.testkubeOrgId }}
-        envId: ${{ parameters.testkubeEnvId }}
+        orgId: tkcorg_0f382d90e81ea228
+        envId: tkcenv_943fe797cb48b4d2
         timeoutSeconds: 1800
-
-    # Let's notify the user that the template has completed using the Notification action
-    - id: notify
-      name: Notify
-      action: notification:send
-      input:
-        recipients: entity
-        entityRefs:
-          - user:default/guest
-        title: 'Template executed'
-        info: 'Your template has been executed'
-        severity: 'normal'
 
   # Outputs are displayed to the user after a successful execution of the template.
   output:

--- a/examples/template/template.yaml
+++ b/examples/template/template.yaml
@@ -67,6 +67,17 @@ spec:
         repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
+    # Run the Testkube quality gate after the component is registered.
+    - id: testkube
+      name: Run Testkube quality gate
+      action: testkube:run-test-workflows
+      input:
+        workflows:
+          - name: k6-sample
+        orgId: ${{ parameters.testkubeOrgId }}
+        envId: ${{ parameters.testkubeEnvId }}
+        timeoutSeconds: 1800
+
     # Let's notify the user that the template has completed using the Notification action
     - id: notify
       name: Notify

--- a/examples/template/template.yaml
+++ b/examples/template/template.yaml
@@ -24,6 +24,7 @@ spec:
       input:
         workflows:
           - name: k6-sample
+          - name: postman-junit-report
         orgId: tkcorg_0f382d90e81ea228
         envId: tkcenv_943fe797cb48b4d2
         timeoutSeconds: 1800

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -66,6 +66,7 @@ backend.add(import('@backstage/plugin-signals-backend'));
 
 // testkube
 backend.add(import('@testkube/backstage-plugin-backend'));
+backend.add(import('@testkube/backstage-plugin-backend/scaffolder'));
 
 // auth providers
 backend.add(import('./modules/auth/githubDomainUserProvisioningModule'));

--- a/plugins/testkube-backend/README.md
+++ b/plugins/testkube-backend/README.md
@@ -46,7 +46,8 @@ backend.add(import('@testkube/backstage-plugin-backend/scaffolder'));
 
 The module adds the `testkube:run-test-workflows` action. It is available only
 in enterprise mode and waits for every requested Test Workflow to finish. The
-action fails unless all executions pass.
+action accepts workflow names, a Kubernetes label selector, or both. Matching
+names are de-duplicated, and the action fails unless all executions pass.
 
 ```yaml
 - id: testkube
@@ -59,6 +60,15 @@ action fails unless all executions pass.
     orgId: tkcorg_0000000000
     envId: tkcenv_0000000000
     timeoutSeconds: 1800
+```
+
+To select workflows by label:
+
+```yaml
+input:
+  selector: app=backend,environment=staging
+  orgId: tkcorg_0000000000
+  envId: tkcenv_0000000000
 ```
 
 The action outputs an overall `green` or `red` status and one result per

--- a/plugins/testkube-backend/README.md
+++ b/plugins/testkube-backend/README.md
@@ -35,6 +35,37 @@ backend.start();
 
 In this repository you can see a complete example in `packages/backend/src/index.ts`.
 
+## Scaffolder quality gate
+
+Register the optional Testkube Scaffolder module alongside the backend plugin:
+
+```ts
+backend.add(import('@testkube/backstage-plugin-backend'));
+backend.add(import('@testkube/backstage-plugin-backend/scaffolder'));
+```
+
+The module adds the `testkube:run-test-workflows` action. It is available only
+in enterprise mode and waits for every requested Test Workflow to finish. The
+action fails unless all executions pass.
+
+```yaml
+- id: testkube
+  name: Run Testkube quality gate
+  action: testkube:run-test-workflows
+  input:
+    workflows:
+      - api-smoke-test
+      - browser-smoke-test
+    orgId: tkcorg_0000000000
+    envId: tkcenv_0000000000
+    timeoutSeconds: 1800
+```
+
+The action outputs an overall `green` or `red` status and one result per
+execution containing its Testkube status and dashboard URL. Organization API
+keys continue to come exclusively from the backend `testkube.organizations`
+configuration.
+
 ## Configuration
 
 The plugin reads its configuration from the `testkube` section of `app-config.yaml`.

--- a/plugins/testkube-backend/README.md
+++ b/plugins/testkube-backend/README.md
@@ -65,10 +65,15 @@ names are de-duplicated, and the action fails unless all executions pass.
             region: [legacy]
           replicate: [runner-1, runner-2]
       - name: browser-smoke-test
+    tags:
+      component: payments
     orgId: tkcorg_0000000000
     envId: tkcenv_0000000000
     timeoutSeconds: 1800
 ```
+
+Every execution includes `executedFrom: backstage`. Additional action-level
+tags are applied to all explicitly named and label-selected workflows.
 
 To select workflows by label:
 

--- a/plugins/testkube-backend/README.md
+++ b/plugins/testkube-backend/README.md
@@ -55,8 +55,16 @@ names are de-duplicated, and the action fails unless all executions pass.
   action: testkube:run-test-workflows
   input:
     workflows:
-      - api-smoke-test
-      - browser-smoke-test
+      - name: api-smoke-test
+        config:
+          workers: '2'
+        target:
+          match:
+            environment: [staging]
+          not:
+            region: [legacy]
+          replicate: [runner-1, runner-2]
+      - name: browser-smoke-test
     orgId: tkcorg_0000000000
     envId: tkcenv_0000000000
     timeoutSeconds: 1800

--- a/plugins/testkube-backend/README.md
+++ b/plugins/testkube-backend/README.md
@@ -72,8 +72,9 @@ names are de-duplicated, and the action fails unless all executions pass.
     timeoutSeconds: 1800
 ```
 
-Every execution includes `executedFrom: backstage`. Additional action-level
-tags are applied to all explicitly named and label-selected workflows.
+Every execution includes `executedFrom: backstage` and the current Backstage
+`taskId`. Additional action-level tags are applied to all explicitly named and
+label-selected workflows.
 
 To select workflows by label:
 

--- a/plugins/testkube-backend/package.json
+++ b/plugins/testkube-backend/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.7.0",
     "@backstage/config": "^1.3.6",
+    "@backstage/plugin-scaffolder-node": "^0.13.4",
     "express": "^4.22.2"
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
   ],
   "exports": {
     ".": "./src/index.ts",
+    "./scaffolder": "./src/scaffolder.ts",
     "./package.json": "./package.json"
   },
   "repository": {

--- a/plugins/testkube-backend/src/scaffolder.ts
+++ b/plugins/testkube-backend/src/scaffolder.ts
@@ -1,0 +1,4 @@
+export {
+  testkubeScaffolderModule,
+  testkubeScaffolderModule as default,
+} from './scaffolder/module';

--- a/plugins/testkube-backend/src/scaffolder/action.test.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.test.ts
@@ -1,0 +1,250 @@
+import type { ActionContext } from '@backstage/plugin-scaffolder-node';
+
+import type { Config } from '../services/configService';
+import { createRunTestWorkflowsAction } from './action';
+
+const config: Config = {
+  url: 'https://api.testkube.io',
+  uiUrl: 'https://app.testkube.io',
+  isEnterprise: true,
+  skipTlsVerify: false,
+  organizations: [{ id: 'org-1', apiKey: 'secret' }],
+};
+
+const execution = (id: string, status: string) => ({
+  id,
+  name: `execution-${id}`,
+  result: { status },
+});
+
+const response = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+const context = (
+  input: {
+    workflows: string[];
+    orgId: string;
+    envId: string;
+    timeoutSeconds?: number;
+  },
+  outputs: Record<string, unknown>,
+) =>
+  ({
+    input,
+    output: jest.fn((name: string, value: unknown) => {
+      outputs[name] = value;
+    }),
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  } as unknown as ActionContext<any, any>);
+
+const services = (send: jest.Mock) =>
+  ({
+    config,
+    proxyService: { send },
+    enterpriseService: {
+      getOrganizationMetadata: jest
+        .fn()
+        .mockResolvedValue({ id: 'org-1', slug: 'acme' }),
+      getEnvironments: jest
+        .fn()
+        .mockResolvedValue([{ id: 'env-1', slug: 'production' }]),
+    },
+  } as unknown as Parameters<typeof createRunTestWorkflowsAction>[0]);
+
+describe('testkube:run-test-workflows', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns green execution links when every workflow passes', async () => {
+    const send = jest
+      .fn()
+      .mockResolvedValueOnce(response([execution('run-1', 'passed')]))
+      .mockResolvedValueOnce(response([execution('run-2', 'passed')]));
+    const outputs: Record<string, unknown> = {};
+    const action = createRunTestWorkflowsAction(services(send));
+
+    await action.handler(
+      context(
+        {
+          workflows: ['api', 'browser'],
+          orgId: 'org-1',
+          envId: 'env-1',
+        },
+        outputs,
+      ),
+    );
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/v1/test-workflows/api/executions',
+        method: 'POST',
+        orgId: 'org-1',
+        envId: 'env-1',
+        apiKey: 'secret',
+      }),
+    );
+    expect(outputs).toEqual({
+      status: 'green',
+      results: [
+        {
+          workflow: 'api',
+          executionId: 'run-1',
+          testkubeStatus: 'passed',
+          status: 'green',
+          url: 'https://app.testkube.io/organization/acme/environment/production/dashboard/executions/run-1',
+        },
+        {
+          workflow: 'browser',
+          executionId: 'run-2',
+          testkubeStatus: 'passed',
+          status: 'green',
+          url: 'https://app.testkube.io/organization/acme/environment/production/dashboard/executions/run-2',
+        },
+      ],
+    });
+  });
+
+  it('outputs all results before failing a mixed quality gate', async () => {
+    const send = jest
+      .fn()
+      .mockResolvedValueOnce(response([execution('run-1', 'failed')]))
+      .mockResolvedValueOnce(response([execution('run-2', 'passed')]));
+    const outputs: Record<string, unknown> = {};
+    const action = createRunTestWorkflowsAction(services(send));
+
+    await expect(
+      action.handler(
+        context(
+          {
+            workflows: ['api', 'browser'],
+            orgId: 'org-1',
+            envId: 'env-1',
+          },
+          outputs,
+        ),
+      ),
+    ).rejects.toThrow('Testkube quality gate failed: api: failed');
+
+    expect(outputs.status).toBe('red');
+    expect(outputs.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workflow: 'api',
+          testkubeStatus: 'failed',
+          status: 'red',
+        }),
+        expect.objectContaining({
+          workflow: 'browser',
+          testkubeStatus: 'passed',
+          status: 'green',
+        }),
+      ]),
+    );
+  });
+
+  it('polls transient errors until the execution passes', async () => {
+    jest.useFakeTimers();
+    const send = jest
+      .fn()
+      .mockResolvedValueOnce(response([execution('run-1', 'running')]))
+      .mockResolvedValueOnce(response({ error: 'temporary' }, 503))
+      .mockResolvedValueOnce(response(execution('run-1', 'passed')));
+    const outputs: Record<string, unknown> = {};
+    const action = createRunTestWorkflowsAction(services(send));
+
+    const result = action.handler(
+      context(
+        {
+          workflows: ['api'],
+          orgId: 'org-1',
+          envId: 'env-1',
+          timeoutSeconds: 30,
+        },
+        outputs,
+      ),
+    );
+
+    await jest.advanceTimersByTimeAsync(10_000);
+    await result;
+
+    expect(send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        path: '/v1/test-workflows/api/executions/run-1',
+        method: 'GET',
+      }),
+    );
+    expect(outputs.status).toBe('green');
+  });
+
+  it('outputs a red timeout and fails the quality gate', async () => {
+    jest.useFakeTimers();
+    const send = jest
+      .fn()
+      .mockResolvedValueOnce(response([execution('run-1', 'running')]))
+      .mockResolvedValueOnce(response(execution('run-1', 'running')));
+    const outputs: Record<string, unknown> = {};
+    const action = createRunTestWorkflowsAction(services(send));
+
+    const result = action.handler(
+      context(
+        {
+          workflows: ['api'],
+          orgId: 'org-1',
+          envId: 'env-1',
+          timeoutSeconds: 5,
+        },
+        outputs,
+      ),
+    );
+
+    const expectation = expect(result).rejects.toThrow(
+      'Testkube quality gate failed: api: timeout',
+    );
+    await jest.advanceTimersByTimeAsync(5_000);
+    await expectation;
+
+    expect(outputs.results).toEqual([
+      expect.objectContaining({
+        testkubeStatus: 'timeout',
+        status: 'red',
+      }),
+    ]);
+  });
+
+  it('rejects standalone mode and unknown organizations', async () => {
+    const outputs: Record<string, unknown> = {};
+    const standalone = createRunTestWorkflowsAction({
+      ...services(jest.fn()),
+      config: { ...config, isEnterprise: false },
+    });
+
+    await expect(
+      standalone.handler(
+        context(
+          { workflows: ['api'], orgId: 'org-1', envId: 'env-1' },
+          outputs,
+        ),
+      ),
+    ).rejects.toThrow('requires testkube.enterprise: true');
+
+    const unknownOrg = createRunTestWorkflowsAction(services(jest.fn()));
+    await expect(
+      unknownOrg.handler(
+        context(
+          { workflows: ['api'], orgId: 'unknown', envId: 'env-1' },
+          outputs,
+        ),
+      ),
+    ).rejects.toThrow('Testkube organization is not configured: unknown');
+  });
+});

--- a/plugins/testkube-backend/src/scaffolder/action.test.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.test.ts
@@ -308,11 +308,12 @@ describe('testkube:run-test-workflows', () => {
       ),
     );
 
-    const expectation = expect(result).rejects.toThrow(
-      'Testkube quality gate failed: api: timeout',
-    );
-    await jest.advanceTimersByTimeAsync(5_000);
-    await expectation;
+    await Promise.all([
+      expect(result).rejects.toThrow(
+        'Testkube quality gate failed: api: timeout',
+      ),
+      jest.advanceTimersByTimeAsync(5_000),
+    ]);
 
     expect(outputs.results).toEqual([
       expect.objectContaining({

--- a/plugins/testkube-backend/src/scaffolder/action.test.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.test.ts
@@ -53,6 +53,7 @@ const context = (
       error: jest.fn(),
       debug: jest.fn(),
     },
+    task: { id: 'task-123' },
   } as unknown as ActionContext<any, any>);
 
 const services = (send: jest.Mock) =>
@@ -118,6 +119,7 @@ describe('testkube:run-test-workflows', () => {
           tags: {
             component: 'payments',
             executedFrom: 'backstage',
+            taskId: 'task-123',
           },
           config: { workers: '2' },
           target: {
@@ -184,7 +186,7 @@ describe('testkube:run-test-workflows', () => {
       expect.objectContaining({
         body: {
           disableWebhooks: false,
-          tags: { executedFrom: 'backstage' },
+          tags: { executedFrom: 'backstage', taskId: 'task-123' },
         },
       }),
     );

--- a/plugins/testkube-backend/src/scaffolder/action.test.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.test.ts
@@ -35,6 +35,7 @@ const context = (
       };
     }>;
     selector?: string;
+    tags?: Record<string, string>;
     orgId: string;
     envId: string;
     timeoutSeconds?: number;
@@ -96,6 +97,7 @@ describe('testkube:run-test-workflows', () => {
             },
             { name: 'browser' },
           ],
+          tags: { component: 'payments', executedFrom: 'override' },
           orgId: 'org-1',
           envId: 'env-1',
         },
@@ -113,6 +115,10 @@ describe('testkube:run-test-workflows', () => {
         apiKey: 'secret',
         body: {
           disableWebhooks: false,
+          tags: {
+            component: 'payments',
+            executedFrom: 'backstage',
+          },
           config: { workers: '2' },
           target: {
             match: { environment: ['staging'] },
@@ -171,6 +177,15 @@ describe('testkube:run-test-workflows', () => {
       expect.objectContaining({
         path: '/v1/test-workflows?selector=app%3Dbackend',
         method: 'GET',
+      }),
+    );
+    expect(send).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        body: {
+          disableWebhooks: false,
+          tags: { executedFrom: 'backstage' },
+        },
       }),
     );
     expect(send).toHaveBeenCalledTimes(3);

--- a/plugins/testkube-backend/src/scaffolder/action.test.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.test.ts
@@ -25,7 +25,15 @@ const response = (body: unknown, status = 200) =>
 
 const context = (
   input: {
-    workflows?: string[];
+    workflows?: Array<{
+      name: string;
+      config?: Record<string, string>;
+      target?: {
+        match?: Record<string, string[]>;
+        not?: Record<string, string[]>;
+        replicate?: string[];
+      };
+    }>;
     selector?: string;
     orgId: string;
     envId: string;
@@ -68,15 +76,26 @@ describe('testkube:run-test-workflows', () => {
   it('returns green execution links when every workflow passes', async () => {
     const send = jest
       .fn()
-      .mockResolvedValueOnce(response([execution('run-1', 'passed')]))
-      .mockResolvedValueOnce(response([execution('run-2', 'passed')]));
+      .mockResolvedValueOnce(response(execution('run-1', 'passed')))
+      .mockResolvedValueOnce(response(execution('run-2', 'passed')));
     const outputs: Record<string, unknown> = {};
     const action = createRunTestWorkflowsAction(services(send));
 
     await action.handler(
       context(
         {
-          workflows: ['api', 'browser'],
+          workflows: [
+            {
+              name: 'api',
+              config: { workers: '2' },
+              target: {
+                match: { environment: ['staging'] },
+                not: { region: ['legacy'] },
+                replicate: ['runner-1'],
+              },
+            },
+            { name: 'browser' },
+          ],
           orgId: 'org-1',
           envId: 'env-1',
         },
@@ -92,6 +111,15 @@ describe('testkube:run-test-workflows', () => {
         orgId: 'org-1',
         envId: 'env-1',
         apiKey: 'secret',
+        body: {
+          disableWebhooks: false,
+          config: { workers: '2' },
+          target: {
+            match: { environment: ['staging'] },
+            not: { region: ['legacy'] },
+            replicate: ['runner-1'],
+          },
+        },
       }),
     );
     expect(outputs).toEqual({
@@ -129,7 +157,7 @@ describe('testkube:run-test-workflows', () => {
     await action.handler(
       context(
         {
-          workflows: ['api'],
+          workflows: [{ name: 'api' }],
           selector: 'app=backend',
           orgId: 'org-1',
           envId: 'env-1',
@@ -173,8 +201,8 @@ describe('testkube:run-test-workflows', () => {
   it('outputs all results before failing a mixed quality gate', async () => {
     const send = jest
       .fn()
-      .mockResolvedValueOnce(response([execution('run-1', 'failed')]))
-      .mockResolvedValueOnce(response([execution('run-2', 'passed')]));
+      .mockResolvedValueOnce(response(execution('run-1', 'failed')))
+      .mockResolvedValueOnce(response(execution('run-2', 'passed')));
     const outputs: Record<string, unknown> = {};
     const action = createRunTestWorkflowsAction(services(send));
 
@@ -182,7 +210,7 @@ describe('testkube:run-test-workflows', () => {
       action.handler(
         context(
           {
-            workflows: ['api', 'browser'],
+            workflows: [{ name: 'api' }, { name: 'browser' }],
             orgId: 'org-1',
             envId: 'env-1',
           },
@@ -212,7 +240,7 @@ describe('testkube:run-test-workflows', () => {
     jest.useFakeTimers();
     const send = jest
       .fn()
-      .mockResolvedValueOnce(response([execution('run-1', 'running')]))
+      .mockResolvedValueOnce(response(execution('run-1', 'running')))
       .mockResolvedValueOnce(response({ error: 'temporary' }, 503))
       .mockResolvedValueOnce(response(execution('run-1', 'passed')));
     const outputs: Record<string, unknown> = {};
@@ -221,7 +249,7 @@ describe('testkube:run-test-workflows', () => {
     const result = action.handler(
       context(
         {
-          workflows: ['api'],
+          workflows: [{ name: 'api' }],
           orgId: 'org-1',
           envId: 'env-1',
           timeoutSeconds: 30,
@@ -246,7 +274,7 @@ describe('testkube:run-test-workflows', () => {
     jest.useFakeTimers();
     const send = jest
       .fn()
-      .mockResolvedValueOnce(response([execution('run-1', 'running')]))
+      .mockResolvedValueOnce(response(execution('run-1', 'running')))
       .mockResolvedValueOnce(response(execution('run-1', 'running')));
     const outputs: Record<string, unknown> = {};
     const action = createRunTestWorkflowsAction(services(send));
@@ -254,7 +282,7 @@ describe('testkube:run-test-workflows', () => {
     const result = action.handler(
       context(
         {
-          workflows: ['api'],
+          workflows: [{ name: 'api' }],
           orgId: 'org-1',
           envId: 'env-1',
           timeoutSeconds: 5,
@@ -287,7 +315,11 @@ describe('testkube:run-test-workflows', () => {
     await expect(
       standalone.handler(
         context(
-          { workflows: ['api'], orgId: 'org-1', envId: 'env-1' },
+          {
+            workflows: [{ name: 'api' }],
+            orgId: 'org-1',
+            envId: 'env-1',
+          },
           outputs,
         ),
       ),
@@ -297,7 +329,11 @@ describe('testkube:run-test-workflows', () => {
     await expect(
       unknownOrg.handler(
         context(
-          { workflows: ['api'], orgId: 'unknown', envId: 'env-1' },
+          {
+            workflows: [{ name: 'api' }],
+            orgId: 'unknown',
+            envId: 'env-1',
+          },
           outputs,
         ),
       ),

--- a/plugins/testkube-backend/src/scaffolder/action.test.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.test.ts
@@ -25,7 +25,8 @@ const response = (body: unknown, status = 200) =>
 
 const context = (
   input: {
-    workflows: string[];
+    workflows?: string[];
+    selector?: string;
     orgId: string;
     envId: string;
     timeoutSeconds?: number;
@@ -112,6 +113,61 @@ describe('testkube:run-test-workflows', () => {
         },
       ],
     });
+  });
+
+  it('resolves label selectors and de-duplicates explicit workflow names', async () => {
+    const send = jest
+      .fn()
+      .mockResolvedValueOnce(
+        response([{ name: 'api' }, { name: 'browser' }, { name: 'api' }]),
+      )
+      .mockResolvedValueOnce(response([execution('run-1', 'passed')]))
+      .mockResolvedValueOnce(response([execution('run-2', 'passed')]));
+    const outputs: Record<string, unknown> = {};
+    const action = createRunTestWorkflowsAction(services(send));
+
+    await action.handler(
+      context(
+        {
+          workflows: ['api'],
+          selector: 'app=backend',
+          orgId: 'org-1',
+          envId: 'env-1',
+        },
+        outputs,
+      ),
+    );
+
+    expect(send).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: '/v1/test-workflows?selector=app%3Dbackend',
+        method: 'GET',
+      }),
+    );
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(outputs.results).toEqual([
+      expect.objectContaining({ workflow: 'api', status: 'green' }),
+      expect.objectContaining({ workflow: 'browser', status: 'green' }),
+    ]);
+  });
+
+  it('fails when a selector matches no workflows', async () => {
+    const send = jest.fn().mockResolvedValue(response([]));
+    const action = createRunTestWorkflowsAction(services(send));
+
+    await expect(
+      action.handler(
+        context(
+          {
+            selector: 'app=missing',
+            orgId: 'org-1',
+            envId: 'env-1',
+          },
+          {},
+        ),
+      ),
+    ).rejects.toThrow('No Testkube workflows matched selector: app=missing');
   });
 
   it('outputs all results before failing a mixed quality gate', async () => {

--- a/plugins/testkube-backend/src/scaffolder/action.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.ts
@@ -233,7 +233,11 @@ export const createRunTestWorkflowsAction = ({
           `No Testkube workflows matched selector: ${ctx.input.selector}`,
         );
       }
-      const tags = { ...ctx.input.tags, executedFrom: 'backstage' };
+      const tags = {
+        ...ctx.input.tags,
+        executedFrom: 'backstage',
+        taskId: ctx.task.id,
+      };
 
       const triggers = await Promise.allSettled(
         workflows.map(async workflow => {

--- a/plugins/testkube-backend/src/scaffolder/action.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.ts
@@ -1,0 +1,272 @@
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+
+import type EnterpriseService from '../services/enterpriseService';
+import type { Config } from '../services/configService';
+import type ProxyService from '../services/proxyService';
+
+const POLL_INTERVAL_MS = 5_000;
+const TERMINAL_STATUSES = new Set(['passed', 'failed', 'aborted']);
+
+type TestWorkflowExecution = {
+  id: string;
+  name: string;
+  result: {
+    status: string;
+  };
+};
+
+type ActionResult = {
+  workflow: string;
+  executionId?: string;
+  testkubeStatus: string;
+  status: 'green' | 'red';
+  url?: string;
+};
+
+type Services = {
+  config: Config;
+  proxyService: ReturnType<typeof ProxyService>;
+  enterpriseService: ReturnType<typeof EnterpriseService>;
+};
+
+const getErrorMessage = async (response: Response): Promise<string> => {
+  const body = await response.text();
+  return body
+    ? `${response.status} ${response.statusText}: ${body}`
+    : `${response.status} ${response.statusText}`;
+};
+
+const wait = (signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new Error('Testkube workflow polling was cancelled'));
+    };
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, POLL_INTERVAL_MS);
+
+    if (signal?.aborted) {
+      onAbort();
+    } else {
+      signal?.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+
+export const createRunTestWorkflowsAction = ({
+  config,
+  proxyService,
+  enterpriseService,
+}: Services) =>
+  createTemplateAction({
+    id: 'testkube:run-test-workflows',
+    description:
+      'Run Testkube Enterprise Test Workflows and fail unless all executions pass',
+    schema: {
+      input: {
+        workflows: z =>
+          z
+            .array(z.string().min(1))
+            .min(1)
+            .describe('Test Workflow names to execute'),
+        orgId: z => z.string().min(1).describe('Testkube organization ID'),
+        envId: z => z.string().min(1).describe('Testkube environment ID'),
+        timeoutSeconds: z =>
+          z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .default(1800)
+            .describe('Maximum time to wait for all workflows'),
+      },
+      output: {
+        status: z => z.enum(['green', 'red']),
+        results: z =>
+          z.array(
+            z.object({
+              workflow: z.string(),
+              executionId: z.string().optional(),
+              testkubeStatus: z.string(),
+              status: z.enum(['green', 'red']),
+              url: z.string().url().optional(),
+            }),
+          ),
+      },
+    },
+    async handler(ctx) {
+      if (!config.isEnterprise) {
+        throw new Error(
+          'testkube:run-test-workflows requires testkube.enterprise: true',
+        );
+      }
+
+      const org = config.organizations.find(
+        organization => organization.id === ctx.input.orgId,
+      );
+      if (!org) {
+        throw new Error(
+          `Testkube organization is not configured: ${ctx.input.orgId}`,
+        );
+      }
+
+      const [organization, environments] = await Promise.all([
+        enterpriseService.getOrganizationMetadata({ orgId: org.id }),
+        enterpriseService.getEnvironments({ org }),
+      ]);
+      const environment = environments.find(
+        candidate => candidate.id === ctx.input.envId,
+      );
+
+      if (!organization?.slug) {
+        throw new Error(`Testkube organization was not found: ${org.id}`);
+      }
+      if (!environment?.slug) {
+        throw new Error(
+          `Testkube environment was not found: ${ctx.input.envId}`,
+        );
+      }
+
+      const dashboardBaseUrl = `${config.uiUrl}/organization/${organization.slug}/environment/${environment.slug}/dashboard/executions`;
+      const deadline = Date.now() + ctx.input.timeoutSeconds * 1_000;
+      const request = (path: string, method: string, body?: object) =>
+        proxyService.send({
+          path,
+          method,
+          body,
+          orgId: org.id,
+          envId: ctx.input.envId,
+          apiKey: org.apiKey,
+        });
+
+      const triggers = await Promise.allSettled(
+        ctx.input.workflows.map(async workflow => {
+          const response = await request(
+            `/v1/test-workflows/${encodeURIComponent(workflow)}/executions`,
+            'POST',
+            { disableWebhooks: false },
+          );
+          if (!response.ok) {
+            throw new Error(await getErrorMessage(response));
+          }
+
+          const executions = (await response.json()) as TestWorkflowExecution[];
+          if (executions.length === 0) {
+            throw new Error('Testkube returned no executions');
+          }
+          return { workflow, executions };
+        }),
+      );
+
+      const results: ActionResult[] = [];
+      const executions: Array<{
+        workflow: string;
+        execution: TestWorkflowExecution;
+      }> = [];
+
+      triggers.forEach((trigger, index) => {
+        const workflow = ctx.input.workflows[index];
+        if (trigger.status === 'fulfilled') {
+          executions.push(
+            ...trigger.value.executions.map(execution => ({
+              workflow,
+              execution,
+            })),
+          );
+        } else {
+          const message =
+            trigger.reason instanceof Error
+              ? trigger.reason.message
+              : String(trigger.reason);
+          ctx.logger.error(`Failed to trigger Testkube workflow ${workflow}`, {
+            error: message,
+          });
+          results.push({
+            workflow,
+            testkubeStatus: 'trigger_error',
+            status: 'red',
+          });
+        }
+      });
+
+      const completed = await Promise.all(
+        executions.map(async ({ workflow, execution }) => {
+          const url = `${dashboardBaseUrl}/${execution.id}`;
+          let latest = execution;
+
+          while (!TERMINAL_STATUSES.has(latest.result.status)) {
+            if (Date.now() >= deadline) {
+              return {
+                workflow,
+                executionId: execution.id,
+                testkubeStatus: 'timeout',
+                status: 'red' as const,
+                url,
+              };
+            }
+
+            await wait(ctx.signal);
+
+            try {
+              const response = await request(
+                `/v1/test-workflows/${encodeURIComponent(
+                  workflow,
+                )}/executions/${encodeURIComponent(execution.id)}`,
+                'GET',
+              );
+              if (!response.ok) {
+                throw new Error(await getErrorMessage(response));
+              }
+              latest = (await response.json()) as TestWorkflowExecution;
+            } catch (error) {
+              ctx.logger.warn(
+                `Unable to poll Testkube workflow ${workflow}; retrying`,
+                {
+                  executionId: execution.id,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              );
+            }
+          }
+
+          return {
+            workflow,
+            executionId: execution.id,
+            testkubeStatus: latest.result.status,
+            status:
+              latest.result.status === 'passed'
+                ? ('green' as const)
+                : ('red' as const),
+            url,
+          };
+        }),
+      );
+      results.push(...completed);
+
+      const status = results.every(result => result.status === 'green')
+        ? 'green'
+        : 'red';
+      ctx.output('status', status);
+      ctx.output('results', results);
+
+      results.forEach(result => {
+        const log = `${result.status.toUpperCase()}: ${result.workflow} (${
+          result.testkubeStatus
+        })${result.url ? ` ${result.url}` : ''}`;
+        if (result.status === 'green') {
+          ctx.logger.info(log);
+        } else {
+          ctx.logger.error(log);
+        }
+      });
+
+      if (status === 'red') {
+        const failed = results
+          .filter(result => result.status === 'red')
+          .map(result => `${result.workflow}: ${result.testkubeStatus}`)
+          .join(', ');
+        throw new Error(`Testkube quality gate failed: ${failed}`);
+      }
+    },
+  });

--- a/plugins/testkube-backend/src/scaffolder/action.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.ts
@@ -15,6 +15,10 @@ type TestWorkflowExecution = {
   };
 };
 
+type TestWorkflow = {
+  name?: string;
+};
+
 type ActionResult = {
   workflow: string;
   executionId?: string;
@@ -64,23 +68,32 @@ export const createRunTestWorkflowsAction = ({
     description:
       'Run Testkube Enterprise Test Workflows and fail unless all executions pass',
     schema: {
-      input: {
-        workflows: z =>
-          z
-            .array(z.string().min(1))
-            .min(1)
-            .describe('Test Workflow names to execute'),
-        orgId: z => z.string().min(1).describe('Testkube organization ID'),
-        envId: z => z.string().min(1).describe('Testkube environment ID'),
-        timeoutSeconds: z =>
-          z
-            .number()
-            .int()
-            .positive()
-            .optional()
-            .default(1800)
-            .describe('Maximum time to wait for all workflows'),
-      },
+      input: z =>
+        z
+          .object({
+            workflows: z
+              .array(z.string().min(1))
+              .optional()
+              .default([])
+              .describe('Test Workflow names to execute'),
+            selector: z
+              .string()
+              .min(1)
+              .optional()
+              .describe('Kubernetes label selector for Test Workflows'),
+            orgId: z.string().min(1).describe('Testkube organization ID'),
+            envId: z.string().min(1).describe('Testkube environment ID'),
+            timeoutSeconds: z
+              .number()
+              .int()
+              .positive()
+              .optional()
+              .default(1800)
+              .describe('Maximum time to wait for all workflows'),
+          })
+          .refine(input => input.workflows.length > 0 || input.selector, {
+            message: 'At least one workflow name or selector is required',
+          }),
       output: {
         status: z => z.enum(['green', 'red']),
         results: z =>
@@ -140,8 +153,33 @@ export const createRunTestWorkflowsAction = ({
           apiKey: org.apiKey,
         });
 
+      const selectedWorkflows = new Set(ctx.input.workflows);
+      if (ctx.input.selector) {
+        const response = await request(
+          `/v1/test-workflows?selector=${encodeURIComponent(
+            ctx.input.selector,
+          )}`,
+          'GET',
+        );
+        if (!response.ok) {
+          throw new Error(await getErrorMessage(response));
+        }
+
+        const workflows = (await response.json()) as TestWorkflow[];
+        workflows.forEach(workflow => {
+          if (workflow.name) selectedWorkflows.add(workflow.name);
+        });
+      }
+
+      const workflowNames = [...selectedWorkflows];
+      if (workflowNames.length === 0) {
+        throw new Error(
+          `No Testkube workflows matched selector: ${ctx.input.selector}`,
+        );
+      }
+
       const triggers = await Promise.allSettled(
-        ctx.input.workflows.map(async workflow => {
+        workflowNames.map(async workflow => {
           const response = await request(
             `/v1/test-workflows/${encodeURIComponent(workflow)}/executions`,
             'POST',
@@ -166,7 +204,7 @@ export const createRunTestWorkflowsAction = ({
       }> = [];
 
       triggers.forEach((trigger, index) => {
-        const workflow = ctx.input.workflows[index];
+        const workflow = workflowNames[index];
         if (trigger.status === 'fulfilled') {
           executions.push(
             ...trigger.value.executions.map(execution => ({

--- a/plugins/testkube-backend/src/scaffolder/action.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.ts
@@ -64,11 +64,12 @@ const getErrorMessage = async (response: Response): Promise<string> => {
 
 const wait = (signal?: AbortSignal): Promise<void> =>
   new Promise((resolve, reject) => {
+    const timer: { value?: ReturnType<typeof setTimeout> } = {};
     const onAbort = () => {
-      clearTimeout(timeout);
+      if (timer.value) clearTimeout(timer.value);
       reject(new Error('Testkube workflow polling was cancelled'));
     };
-    const timeout = setTimeout(() => {
+    timer.value = setTimeout(() => {
       signal?.removeEventListener('abort', onAbort);
       resolve();
     }, POLL_INTERVAL_MS);

--- a/plugins/testkube-backend/src/scaffolder/action.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.ts
@@ -119,6 +119,11 @@ export const createRunTestWorkflowsAction = ({
               .min(1)
               .optional()
               .describe('Kubernetes label selector for Test Workflows'),
+            tags: z
+              .record(z.string())
+              .optional()
+              .default({})
+              .describe('Tags applied to every Test Workflow execution'),
             orgId: z.string().min(1).describe('Testkube organization ID'),
             envId: z.string().min(1).describe('Testkube environment ID'),
             timeoutSeconds: z
@@ -228,6 +233,7 @@ export const createRunTestWorkflowsAction = ({
           `No Testkube workflows matched selector: ${ctx.input.selector}`,
         );
       }
+      const tags = { ...ctx.input.tags, executedFrom: 'backstage' };
 
       const triggers = await Promise.allSettled(
         workflows.map(async workflow => {
@@ -238,6 +244,7 @@ export const createRunTestWorkflowsAction = ({
             'POST',
             {
               disableWebhooks: false,
+              tags,
               ...(workflow.config && { config: workflow.config }),
               ...(workflow.target && { target: workflow.target }),
             },

--- a/plugins/testkube-backend/src/scaffolder/action.ts
+++ b/plugins/testkube-backend/src/scaffolder/action.ts
@@ -19,6 +19,16 @@ type TestWorkflow = {
   name?: string;
 };
 
+type WorkflowInput = {
+  name: string;
+  config?: Record<string, string>;
+  target?: {
+    match?: Record<string, string[]>;
+    not?: Record<string, string[]>;
+    replicate?: string[];
+  };
+};
+
 type ActionResult = {
   workflow: string;
   executionId?: string;
@@ -31,6 +41,18 @@ type Services = {
   config: Config;
   proxyService: ReturnType<typeof ProxyService>;
   enterpriseService: ReturnType<typeof EnterpriseService>;
+};
+
+const isTestWorkflowExecution = (
+  value: unknown,
+): value is TestWorkflowExecution => {
+  if (!value || typeof value !== 'object') return false;
+  const execution = value as Partial<TestWorkflowExecution>;
+  return (
+    typeof execution.id === 'string' &&
+    typeof execution.name === 'string' &&
+    typeof execution.result?.status === 'string'
+  );
 };
 
 const getErrorMessage = async (response: Response): Promise<string> => {
@@ -72,10 +94,26 @@ export const createRunTestWorkflowsAction = ({
         z
           .object({
             workflows: z
-              .array(z.string().min(1))
+              .array(
+                z.object({
+                  name: z.string().min(1),
+                  config: z.record(z.string()).optional(),
+                  target: z
+                    .object({
+                      match: z
+                        .record(z.array(z.string().min(1)).min(1))
+                        .optional(),
+                      not: z
+                        .record(z.array(z.string().min(1)).min(1))
+                        .optional(),
+                      replicate: z.array(z.string().min(1)).min(1).optional(),
+                    })
+                    .optional(),
+                }),
+              )
               .optional()
               .default([])
-              .describe('Test Workflow names to execute'),
+              .describe('Named Test Workflows and their execution settings'),
             selector: z
               .string()
               .min(1)
@@ -93,7 +131,16 @@ export const createRunTestWorkflowsAction = ({
           })
           .refine(input => input.workflows.length > 0 || input.selector, {
             message: 'At least one workflow name or selector is required',
-          }),
+          })
+          .refine(
+            input =>
+              new Set(input.workflows.map(workflow => workflow.name)).size ===
+              input.workflows.length,
+            {
+              message: 'Workflow names must be unique',
+              path: ['workflows'],
+            },
+          ),
       output: {
         status: z => z.enum(['green', 'red']),
         results: z =>
@@ -153,7 +200,9 @@ export const createRunTestWorkflowsAction = ({
           apiKey: org.apiKey,
         });
 
-      const selectedWorkflows = new Set(ctx.input.workflows);
+      const selectedWorkflows = new Map(
+        (ctx.input.workflows ?? []).map(workflow => [workflow.name, workflow]),
+      );
       if (ctx.input.selector) {
         const response = await request(
           `/v1/test-workflows?selector=${encodeURIComponent(
@@ -167,33 +216,45 @@ export const createRunTestWorkflowsAction = ({
 
         const workflows = (await response.json()) as TestWorkflow[];
         workflows.forEach(workflow => {
-          if (workflow.name) selectedWorkflows.add(workflow.name);
+          if (workflow.name && !selectedWorkflows.has(workflow.name)) {
+            selectedWorkflows.set(workflow.name, { name: workflow.name });
+          }
         });
       }
 
-      const workflowNames = [...selectedWorkflows];
-      if (workflowNames.length === 0) {
+      const workflows = [...selectedWorkflows.values()] as WorkflowInput[];
+      if (workflows.length === 0) {
         throw new Error(
           `No Testkube workflows matched selector: ${ctx.input.selector}`,
         );
       }
 
       const triggers = await Promise.allSettled(
-        workflowNames.map(async workflow => {
+        workflows.map(async workflow => {
           const response = await request(
-            `/v1/test-workflows/${encodeURIComponent(workflow)}/executions`,
+            `/v1/test-workflows/${encodeURIComponent(
+              workflow.name,
+            )}/executions`,
             'POST',
-            { disableWebhooks: false },
+            {
+              disableWebhooks: false,
+              ...(workflow.config && { config: workflow.config }),
+              ...(workflow.target && { target: workflow.target }),
+            },
           );
           if (!response.ok) {
             throw new Error(await getErrorMessage(response));
           }
 
-          const executions = (await response.json()) as TestWorkflowExecution[];
-          if (executions.length === 0) {
-            throw new Error('Testkube returned no executions');
+          const payload: unknown = await response.json();
+          const executions = Array.isArray(payload) ? payload : [payload];
+          if (
+            executions.length === 0 ||
+            !executions.every(isTestWorkflowExecution)
+          ) {
+            throw new Error('Testkube returned an invalid execution response');
           }
-          return { workflow, executions };
+          return { workflow: workflow.name, executions };
         }),
       );
 
@@ -204,7 +265,7 @@ export const createRunTestWorkflowsAction = ({
       }> = [];
 
       triggers.forEach((trigger, index) => {
-        const workflow = workflowNames[index];
+        const workflow = workflows[index].name;
         if (trigger.status === 'fulfilled') {
           executions.push(
             ...trigger.value.executions.map(execution => ({

--- a/plugins/testkube-backend/src/scaffolder/module.ts
+++ b/plugins/testkube-backend/src/scaffolder/module.ts
@@ -1,0 +1,51 @@
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
+
+import CacheService from '../services/cacheService';
+import ConfigService from '../services/configService';
+import EnterpriseService from '../services/enterpriseService';
+import ProxyService from '../services/proxyService';
+import { createRunTestWorkflowsAction } from './action';
+
+export const testkubeScaffolderModule = createBackendModule({
+  pluginId: 'scaffolder',
+  moduleId: 'testkube',
+  register(env) {
+    env.registerInit({
+      deps: {
+        actions: scaffolderActionsExtensionPoint,
+        config: coreServices.rootConfig,
+        logger: coreServices.logger,
+      },
+      async init({ actions, config: backstageConfig, logger }) {
+        const configService = ConfigService();
+        const config = configService.getFromBackstage(backstageConfig);
+        const errors = configService.validate(config);
+        if (errors.length > 0) {
+          throw new Error(errors.join('\n'));
+        }
+
+        const proxyService = ProxyService({ config, logger });
+        const enterpriseService = EnterpriseService({
+          config,
+          proxyService,
+          cacheService: CacheService(),
+          logger,
+        });
+
+        actions.addActions(
+          createRunTestWorkflowsAction({
+            config,
+            proxyService,
+            enterpriseService,
+          }),
+        );
+      },
+    });
+  },
+});
+
+export default testkubeScaffolderModule;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12222,6 +12222,7 @@ __metadata:
     "@backstage/backend-plugin-api": "npm:^1.7.0"
     "@backstage/cli": "npm:^0.36.3"
     "@backstage/config": "npm:^1.3.6"
+    "@backstage/plugin-scaffolder-node": "npm:^0.13.4"
     "@types/express": "npm:^4.17.21"
     express: "npm:^4.22.2"
   languageName: unknown


### PR DESCRIPTION
## What changed

- add a `testkube:run-test-workflows` Backstage Scaffolder action and backend module
- support explicit workflows with config parameters and execution targets, or workflow discovery by label selector
- wait for all executions, expose green/red results with Testkube dashboard links, and fail the step when any workflow fails
- attach configurable execution tags and always include `executedFrom: backstage`
- add enterprise organization/environment routing, timeout handling, polling retries, documentation, and an example template

## Why

Backstage templates need a native Testkube quality gate that can run the same workflow configurations and runner targeting options available through the Testkube CLI/API.

## Validation

- `yarn tsc --incremental --pretty false`
- `CI=true yarn workspace @testkube/backstage-plugin-backend test --runInBand` (20 tests)
- `yarn workspace @testkube/backstage-plugin-backend build`
- `git diff --check`
